### PR TITLE
refactor: per-output addresses for transactions

### DIFF
--- a/boltz/btc.go
+++ b/boltz/btc.go
@@ -99,15 +99,10 @@ func btcTaprootHash(transaction Transaction, outputs []OutputDetails, index int)
 	)
 }
 
-func constructBtcTransaction(network *Network, outputs []OutputDetails, outputAddressRaw string, fee uint64) (Transaction, error) {
-	outputAddress, err := btcutil.DecodeAddress(outputAddressRaw, network.Btc)
-	if err != nil {
-		return nil, errors.New("Could not decode address: " + err.Error())
-	}
-
+func constructBtcTransaction(network *Network, outputs []OutputDetails, fee uint64) (Transaction, error) {
 	transaction := wire.NewMsgTx(wire.TxVersion)
 
-	var inputSum int64
+	outValues := make(map[string]int64)
 
 	for _, output := range outputs {
 		// Set the highest timeout block height as locktime
@@ -119,27 +114,38 @@ func constructBtcTransaction(network *Network, outputs []OutputDetails, outputAd
 
 		lockupTx := output.LockupTransaction.(*BtcTransaction).Tx
 
-		// Calculate the sum of all inputs
-		inputSum += lockupTx.MsgTx().TxOut[output.Vout].Value
-
 		// Add the input to the transaction
 		input := wire.NewTxIn(wire.NewOutPoint(lockupTx.Hash(), output.Vout), nil, nil)
 		input.Sequence = 0
 
 		transaction.AddTxIn(input)
+
+		value := lockupTx.MsgTx().TxOut[output.Vout].Value
+		//nolint:gosimple
+		existingValue, _ := outValues[output.Address]
+		outValues[output.Address] = existingValue + value
+
 	}
 
-	// Add the output
-	outputScript, err := txscript.PayToAddrScript(outputAddress)
+	feePerOutput := fee / uint64(len(outValues))
 
-	if err != nil {
-		return nil, err
+	for rawAddress, value := range outValues {
+		outputAddress, err := btcutil.DecodeAddress(rawAddress, network.Btc)
+		if err != nil {
+			return nil, errors.New("Could not decode address: " + err.Error())
+		}
+
+		// Add the output
+		outputScript, err := txscript.PayToAddrScript(outputAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		transaction.AddTxOut(&wire.TxOut{
+			PkScript: outputScript,
+			Value:    value - int64(feePerOutput),
+		})
 	}
-
-	transaction.AddTxOut(&wire.TxOut{
-		PkScript: outputScript,
-		Value:    inputSum - int64(fee),
-	})
 
 	prevoutFetcher := getPrevoutFetcher(transaction, outputs)
 	sigHashes := txscript.NewTxSigHashes(transaction, prevoutFetcher)

--- a/boltz/btc.go
+++ b/boltz/btc.go
@@ -127,7 +127,9 @@ func constructBtcTransaction(network *Network, outputs []OutputDetails, fee uint
 
 	}
 
-	feePerOutput := fee / uint64(len(outValues))
+	outLen := uint64(len(outValues))
+	feePerOutput := fee / outLen
+	feeRemainder := fee % outLen
 
 	for rawAddress, value := range outValues {
 		outputAddress, err := btcutil.DecodeAddress(rawAddress, network.Btc)
@@ -141,9 +143,12 @@ func constructBtcTransaction(network *Network, outputs []OutputDetails, fee uint
 			return nil, err
 		}
 
+		// give the remainder to the first output
+		fee := feePerOutput + feeRemainder
+		feeRemainder = 0
 		transaction.AddTxOut(&wire.TxOut{
 			PkScript: outputScript,
-			Value:    value - int64(feePerOutput),
+			Value:    value - int64(fee),
 		})
 	}
 

--- a/boltz/liquid.go
+++ b/boltz/liquid.go
@@ -175,7 +175,10 @@ func constructLiquidTransaction(network *Network, outputs []OutputDetails, fee u
 			Amount: fee,
 		},
 	}
-	feePerOutput := fee / uint64(len(outValues))
+
+	outLen := uint64(len(outValues))
+	feePerOutput := fee / outLen
+	feeRemainder := fee % outLen
 	var blindingKeyCompressed []byte
 	var blinderIndex uint32
 	for rawAddres, value := range outValues {
@@ -200,9 +203,12 @@ func constructLiquidTransaction(network *Network, outputs []OutputDetails, fee u
 			return nil, errors.New("Could not generate output script: " + err.Error())
 		}
 
+		// give the remainder to the first output
+		fee := feePerOutput + feeRemainder
+		feeRemainder = 0
 		txOutputs = append(txOutputs, psetv2.OutputArgs{
 			Asset:        btcAsset,
-			Amount:       value - feePerOutput,
+			Amount:       value - fee,
 			Script:       script,
 			BlindingKey:  blindingKeyCompressed,
 			BlinderIndex: blinderIndex,

--- a/boltz/liquid.go
+++ b/boltz/liquid.go
@@ -107,30 +107,7 @@ func liquidTaprootHash(transaction *liquidtx.Transaction, network *Network, outp
 	return hash[:]
 }
 
-func constructLiquidTransaction(network *Network, outputs []OutputDetails, outputAddressRaw string, fee uint64) (Transaction, error) {
-	var blindingKeyCompressed []byte
-
-	isConfidential, err := address.IsConfidential(outputAddressRaw)
-	if err != nil {
-		return nil, errors.New("Could not decode address: " + err.Error())
-	}
-
-	if isConfidential {
-		outputAddress, err := address.FromConfidential(outputAddressRaw)
-		if err != nil {
-			return nil, errors.New("Could not decode address: " + err.Error())
-		}
-		blindingKey, err := btcec.ParsePubKey(outputAddress.BlindingKey)
-		if err != nil {
-			return nil, errors.New("Could not parse blinding key: " + err.Error())
-		}
-		blindingKeyCompressed = blindingKey.SerializeCompressed()
-	}
-	script, err := address.ToOutputScript(outputAddressRaw)
-	if err != nil {
-		return nil, errors.New("Could not generate output script: " + err.Error())
-	}
-
+func constructLiquidTransaction(network *Network, outputs []OutputDetails, fee uint64) (Transaction, error) {
 	p, err := psetv2.New(nil, nil, nil)
 	if err != nil {
 		return nil, err
@@ -182,26 +159,58 @@ func constructLiquidTransaction(network *Network, outputs []OutputDetails, outpu
 		return nil, errors.New("Failed to unblind inputs: " + err.Error())
 	}
 
-	var inputSum uint64
-	for _, input := range ownedInputs {
-		inputSum += input.Value
+	outValues := make(map[string]uint64)
+	for i, input := range ownedInputs {
+		address := outputs[i].Address
+		//nolint:gosimple
+		existingValue, _ := outValues[address]
+		outValues[address] = existingValue + input.Value
 	}
 
 	btcAsset := network.Liquid.AssetID
 
-	if err := updater.AddOutputs([]psetv2.OutputArgs{
-		{
-			Asset:        btcAsset,
-			Amount:       inputSum - fee,
-			Script:       script,
-			BlindingKey:  blindingKeyCompressed,
-			BlinderIndex: 0,
-		},
+	txOutputs := []psetv2.OutputArgs{
 		{
 			Asset:  btcAsset,
 			Amount: fee,
 		},
-	}); err != nil {
+	}
+	feePerOutput := fee / uint64(len(outValues))
+	var blindingKeyCompressed []byte
+	var blinderIndex uint32
+	for rawAddres, value := range outValues {
+		isConfidential, err := address.IsConfidential(rawAddres)
+		if err != nil {
+			return nil, errors.New("Could not decode address: " + err.Error())
+		}
+
+		if isConfidential {
+			outputAddress, err := address.FromConfidential(rawAddres)
+			if err != nil {
+				return nil, errors.New("Could not decode address: " + err.Error())
+			}
+			blindingKey, err := btcec.ParsePubKey(outputAddress.BlindingKey)
+			if err != nil {
+				return nil, errors.New("Could not parse blinding key: " + err.Error())
+			}
+			blindingKeyCompressed = blindingKey.SerializeCompressed()
+		}
+		script, err := address.ToOutputScript(rawAddres)
+		if err != nil {
+			return nil, errors.New("Could not generate output script: " + err.Error())
+		}
+
+		txOutputs = append(txOutputs, psetv2.OutputArgs{
+			Asset:        btcAsset,
+			Amount:       value - feePerOutput,
+			Script:       script,
+			BlindingKey:  blindingKeyCompressed,
+			BlinderIndex: blinderIndex,
+		})
+		blinderIndex += 1
+	}
+
+	if err := updater.AddOutputs(txOutputs); err != nil {
 		return nil, err
 	}
 

--- a/boltz/transaction.go
+++ b/boltz/transaction.go
@@ -23,6 +23,9 @@ type OutputDetails struct {
 	LockupTransaction Transaction
 	Vout              uint32
 
+	// which address to use as the destination for the output
+	Address string
+
 	PrivateKey *btcec.PrivateKey
 
 	// Should be set to an empty array in case of a refund
@@ -54,8 +57,8 @@ func NewTxFromHex(currency Currency, hexString string, ourOutputBlindingKey *btc
 	return NewBtcTxFromHex(hexString)
 }
 
-func ConstructTransaction(network *Network, currency Currency, outputs []OutputDetails, outputAddress string, satPerVbyte float64, boltzApi *Boltz) (Transaction, uint64, error) {
-	var construct func(*Network, []OutputDetails, string, uint64) (Transaction, error)
+func ConstructTransaction(network *Network, currency Currency, outputs []OutputDetails, satPerVbyte float64, boltzApi *Boltz) (Transaction, uint64, error) {
+	var construct func(*Network, []OutputDetails, uint64) (Transaction, error)
 	if currency == CurrencyLiquid {
 		construct = constructLiquidTransaction
 	} else if currency == CurrencyBtc {
@@ -64,14 +67,14 @@ func ConstructTransaction(network *Network, currency Currency, outputs []OutputD
 		return nil, 0, fmt.Errorf("invalid pair: %v", currency)
 	}
 
-	noFeeTransaction, err := construct(network, outputs, outputAddress, 0)
+	noFeeTransaction, err := construct(network, outputs, 0)
 
 	if err != nil {
 		return nil, 0, err
 	}
 
 	fee := uint64(float64(noFeeTransaction.VSize()) * satPerVbyte)
-	transaction, err := construct(network, outputs, outputAddress, fee)
+	transaction, err := construct(network, outputs, fee)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/cmd/boltzd/boltzd_test.go
+++ b/cmd/boltzd/boltzd_test.go
@@ -527,69 +527,8 @@ func TestSwap(t *testing.T) {
 						submarinePair, err := client.GetSubmarinePair(pair)
 
 						require.NoError(t, err)
-						amount := submarinePair.Limits.Minimal
-
-						t.Run("Script", func(t *testing.T) {
-							cfg.Boltz.DisablePartialSignatures = true
-							swaps := make([]*boltzrpc.CreateSwapResponse, 3)
-
-							refundAddress := cli("getnewaddress")
-							swaps[0], err = client.CreateSwap(&boltzrpc.CreateSwapRequest{
-								Pair:          pair,
-								RefundAddress: &refundAddress,
-								Amount:        int64(amount + 100),
-							})
-							require.NoError(t, err)
-
-							swaps[1], err = client.CreateSwap(&boltzrpc.CreateSwapRequest{
-								Pair:   pair,
-								Amount: int64(amount + 100),
-							})
-							require.NoError(t, err)
-
-							swaps[2], err = client.CreateSwap(&boltzrpc.CreateSwapRequest{
-								Pair:   pair,
-								Amount: int64(amount + 100),
-							})
-							require.NoError(t, err)
-
-							var streams []nextFunc
-							for _, swap := range swaps {
-								stream := swapStream(t, client, swap.Id)
-								test.SendToAddress(cli, swap.Address, int64(amount))
-								stream(boltzrpc.SwapState_ERROR)
-								streams = append(streams, stream)
-							}
-
-							test.MineUntil(t, cli, int64(swaps[0].TimeoutBlockHeight))
-
-							var infos []*boltzrpc.SwapInfo
-							for _, stream := range streams {
-								info := stream(boltzrpc.SwapState_REFUNDED)
-								require.Zero(t, info.Swap.ServiceFee)
-								infos = append(infos, info.Swap)
-								test.MineBlock()
-							}
-
-							from := parseCurrency(pair.From)
-
-							require.NotEqual(t, infos[0].RefundTransactionId, infos[1].RefundTransactionId)
-							require.Equal(t, infos[1].RefundTransactionId, infos[2].RefundTransactionId)
-
-							refundFee, err := chain.GetTransactionFee(from, infos[1].RefundTransactionId)
-							require.NoError(t, err)
-
-							require.Equal(t, int(refundFee), int(*infos[1].OnchainFee)+int(*infos[2].OnchainFee))
-
-							checkTxOutAddress(t, chain, from, infos[0].RefundTransactionId, refundAddress, false)
-
-							refundFee, err = chain.GetTransactionFee(from, infos[0].RefundTransactionId)
-							require.NoError(t, err)
-							require.Equal(t, int(refundFee), int(*infos[0].OnchainFee))
-						})
 
 						createFailedSwap := func(t *testing.T, refundAddress string) nextFunc {
-							cfg.Boltz.DisablePartialSignatures = false
 							amount := submarinePair.Limits.Minimal + 100
 							swap, err := client.CreateSwap(&boltzrpc.CreateSwapRequest{
 								Pair:          pair,
@@ -603,7 +542,35 @@ func TestSwap(t *testing.T) {
 							return stream
 						}
 
+						t.Run("Script", func(t *testing.T) {
+							cfg.Boltz.DisablePartialSignatures = true
+
+							refundAddress := cli("getnewaddress")
+							withStream := createFailedSwap(t, refundAddress)
+							withoutStream := createFailedSwap(t, "")
+
+							withInfo := withStream(boltzrpc.SwapState_ERROR).Swap
+							withoutStream(boltzrpc.SwapState_ERROR)
+
+							test.MineUntil(t, cli, int64(withInfo.TimeoutBlockHeight))
+
+							withInfo = withStream(boltzrpc.SwapState_REFUNDED).Swap
+							withoutInfo := withoutStream(boltzrpc.SwapState_REFUNDED).Swap
+
+							from := parseCurrency(pair.From)
+
+							require.Equal(t, withInfo.RefundTransactionId, withoutInfo.RefundTransactionId)
+							refundFee, err := chain.GetTransactionFee(from, withInfo.RefundTransactionId)
+							require.NoError(t, err)
+
+							require.Equal(t, int(refundFee), int(*withInfo.OnchainFee)+int(*withoutInfo.OnchainFee))
+
+							checkTxOutAddress(t, chain, from, withInfo.RefundTransactionId, refundAddress, false)
+						})
+
 						t.Run("Cooperative", func(t *testing.T) {
+							cfg.Boltz.DisablePartialSignatures = false
+
 							refundAddress := cli("getnewaddress")
 							stream := createFailedSwap(t, refundAddress)
 

--- a/nursery/nursery.go
+++ b/nursery/nursery.go
@@ -247,8 +247,8 @@ func (nursery *Nursery) getFeeEstimation(currency boltz.Currency) (float64, erro
 	return nursery.onchain.EstimateFee(currency, 2)
 }
 
-func (nursery *Nursery) createTransaction(currency boltz.Currency, outputs []boltz.OutputDetails, address string, feeSatPerVbyte float64) (string, uint64, error) {
-	transaction, fee, err := boltz.ConstructTransaction(nursery.network, currency, outputs, address, feeSatPerVbyte, nursery.boltz)
+func (nursery *Nursery) createTransaction(currency boltz.Currency, outputs []boltz.OutputDetails, feeSatPerVbyte float64) (string, uint64, error) {
+	transaction, fee, err := boltz.ConstructTransaction(nursery.network, currency, outputs, feeSatPerVbyte, nursery.boltz)
 	if err != nil {
 		return "", 0, fmt.Errorf("construct transaction: %v", err)
 	}

--- a/nursery/reverse.go
+++ b/nursery/reverse.go
@@ -134,6 +134,7 @@ func (nursery *Nursery) handleReverseSwapStatus(reverseSwap *database.ReverseSwa
 			SwapType:          boltz.ReverseSwap,
 			LockupTransaction: lockupTx,
 			Vout:              lockupVout,
+			Address:           reverseSwap.ClaimAddress,
 			PrivateKey:        reverseSwap.PrivateKey,
 			Preimage:          reverseSwap.Preimage,
 			SwapTree:          reverseSwap.SwapTree,
@@ -213,5 +214,5 @@ func (nursery *Nursery) handleReverseSwapStatus(reverseSwap *database.ReverseSwa
 }
 
 func (nursery *Nursery) claimReverseSwap(reverseSwap *database.ReverseSwap, output boltz.OutputDetails, feeSatPerVbyte float64) (string, uint64, error) {
-	return nursery.createTransaction(reverseSwap.Pair.To, []boltz.OutputDetails{output}, reverseSwap.ClaimAddress, feeSatPerVbyte)
+	return nursery.createTransaction(reverseSwap.Pair.To, []boltz.OutputDetails{output}, feeSatPerVbyte)
 }

--- a/nursery/swap.go
+++ b/nursery/swap.go
@@ -59,37 +59,16 @@ func (nursery *Nursery) RefundSwaps(swapsToRefund []database.Swap, cooperative b
 
 	var refundedSwaps []database.Swap
 	var refundOutputs []boltz.OutputDetails
-	var refundAddress string
 
 	for _, swapToRefund := range swapsToRefund {
 		refundOutput, err := nursery.getRefundOutput(&swapToRefund)
 		if err != nil {
-			logger.Warnf("Could not get refund output of swap %s: %v", swapToRefund.Id, err)
-			continue
+			return fmt.Errorf("Could not get refund output of swap %s: %v", swapToRefund.Id, err)
 		}
 
 		refundOutput.Cooperative = cooperative
-		if swapToRefund.RefundAddress != "" {
-			// we process all swaps that have an explicit refund address isolated
-			refundedSwaps = []database.Swap{swapToRefund}
-			refundOutputs = []boltz.OutputDetails{*refundOutput}
-			refundAddress = swapToRefund.RefundAddress
-			break
-		}
 		refundedSwaps = append(refundedSwaps, swapToRefund)
 		refundOutputs = append(refundOutputs, *refundOutput)
-	}
-
-	if refundAddress == "" {
-		wallet, err := nursery.onchain.GetAnyWallet(currency, true)
-		if err != nil {
-			message := "%d Swaps can not be refunded because they got no refund address and no wallet for currency %s is available! Set up a wallet or refund manually"
-			return fmt.Errorf(message, len(refundedSwaps), currency)
-		}
-		refundAddress, err = wallet.NewAddress()
-		if err != nil {
-			return fmt.Errorf("%d Swaps can not be refunded because they got no refund address and wallet failed to generate address: %v", len(refundedSwaps), err)
-		}
 	}
 
 	if len(refundOutputs) == 0 {
@@ -98,16 +77,15 @@ func (nursery *Nursery) RefundSwaps(swapsToRefund []database.Swap, cooperative b
 	}
 
 	feeSatPerVbyte, err := nursery.getFeeEstimation(currency)
-
 	if err != nil {
 		return errors.New("Could not get fee estimation: " + err.Error())
 	}
 
 	logger.Info(fmt.Sprintf("Using fee of %v sat/vbyte for refund transaction", feeSatPerVbyte))
 
-	refundTransactionId, totalRefundFee, err := nursery.createTransaction(currency, refundOutputs, refundAddress, feeSatPerVbyte)
+	refundTransactionId, totalRefundFee, err := nursery.createTransaction(currency, refundOutputs, feeSatPerVbyte)
 	if err != nil {
-		return errors.New("Could not create refund transaction: " + err.Error())
+		return err
 	}
 
 	logger.Infof("Constructed refund transaction for %d swaps: %s", len(refundOutputs), refundTransactionId)
@@ -144,11 +122,33 @@ func (nursery *Nursery) getRefundOutput(swap *database.Swap) (*boltz.OutputDetai
 		return nil, fmt.Errorf("could not find lockup vout of Swap %s: %w", swap.Id, err)
 	}
 
+	if swap.RefundAddress == "" {
+		currency := swap.Pair.From
+		wallet, err := nursery.onchain.GetAnyWallet(currency, true)
+		if err != nil {
+			message := "Swap %s can not be refunded because they got no refund address and no wallet for currency %s is available. Setup a wallet or refund manually"
+			return nil, fmt.Errorf(message, swap.Id, currency)
+		}
+		if swap.Wallet != "" {
+			wallet, err = nursery.onchain.GetWallet(swap.Wallet, currency, true)
+			if err != nil {
+				message := "Swap %s can not be refunded because the wallet is was funded from is not available anymore. Refund manually"
+				return nil, fmt.Errorf(message, swap.Id)
+			}
+		}
+		swap.RefundAddress, err = wallet.NewAddress()
+		if err != nil {
+			message := "Swap %s can not be refunded because it has no refund address and the associated wallet failed to generate address: %v"
+			return nil, fmt.Errorf(message, swap.Id, err)
+		}
+	}
+
 	return &boltz.OutputDetails{
 		SwapId:             swap.Id,
 		SwapType:           boltz.NormalSwap,
 		LockupTransaction:  lockupTransaction,
 		Vout:               lockupVout,
+		Address:            swap.RefundAddress,
 		PrivateKey:         swap.PrivateKey,
 		Preimage:           []byte{},
 		TimeoutBlockHeight: swap.TimoutBlockHeight,


### PR DESCRIPTION
Allow specifying a destination address for each output when creating a transaction. This simplifies any form of batching, currently swap refunds, but can be used for deferred claims of reverse / chain swaps aswell