### PR TITLE
fix: add space

### DIFF
--- a/cmd/boltzcli/commands.go
+++ b/cmd/boltzcli/commands.go
@@ -1811,7 +1811,7 @@ func createWallet(ctx *cli.Context, params *boltzrpc.WalletParams) (wallet *bolt
 	fmt.Println()
 	fmt.Println("Mnemonic:\n" + credentials.Mnemonic)
 	fmt.Println()
-	fmt.Println("We highly recommend to import the mnemonic shown above into an external wallet like Blockstream Green (https://blockstream.com/green)." +
+	fmt.Println("We highly recommend to import the mnemonic shown above into an external wallet like Blockstream Green (https://blockstream.com/green). " +
 		"This serves as backup and allows you to view transactions and control your funds.")
 	return credentials.Wallet, nil
 }


### PR DESCRIPTION
`Green (https://blockstream.com/green).This` -> `Green (https://blockstream.com/green). This`