### PR TITLE
feat: add config option for cln server name

### DIFF
--- a/cln/cln.go
+++ b/cln/cln.go
@@ -29,6 +29,7 @@ type Cln struct {
 	RootCert   string `long:"cln.rootcert" description:"Path to the root cert of the CLN gRPC"`
 	PrivateKey string `long:"cln.privatekey" description:"Path to the client key of the CLN gRPC"`
 	CertChain  string `long:"cln.certchain" description:"Path to the client cert of the CLN gRPC"`
+	ServerName string `long:"cln.servername" description:"Server name used in the certificate"`
 
 	Client protos.NodeClient
 
@@ -76,7 +77,7 @@ func (c *Cln) Connect() error {
 	}
 
 	creds := credentials.NewTLS(&tls.Config{
-		ServerName:   "cln",
+		ServerName:   c.ServerName,
 		RootCAs:      caPool,
 		Certificates: []tls.Certificate{cert},
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,7 @@ func LoadConfig(dataDir string) (*Config, error) {
 			RootCert:   "",
 			PrivateKey: "",
 			CertChain:  "",
+			ServerName: "cln",
 		},
 
 		RPC: &rpcserver.RpcServer{

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ The daemon connects to CLN through [gRPC](https://docs.corelightning.org/docs/gr
 * `--cln.datadir` data directory of cln (`~/.lightning` by default)
 
 You can manually set the paths of `cln.rootcert`, `cln.privatekey` and `cln.certchain` instead of speciyfing the data directory as well.
-You might have to set the `cln.servername` option aswell if you are using a custom certificate.
+You might have to set the `cln.servername` option as well, if you are using a custom certificate.
 
 ### CLI
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ The daemon connects to CLN through [gRPC](https://docs.corelightning.org/docs/gr
 * `--cln.datadir` data directory of cln (`~/.lightning` by default)
 
 You can manually set the paths of `cln.rootcert`, `cln.privatekey` and `cln.certchain` instead of speciyfing the data directory as well.
+You might have to set the `cln.servername` option aswell if you are using a custom certificate.
 
 ### CLI
 


### PR DESCRIPTION
This PR allows setting a custom cln server name through the `cln.servername` config value.

closes: #218 