### PR TITLE
fix: pass configured electrum url to gdk

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -75,11 +75,17 @@ type Config struct {
 	ElectrumSSL       bool   `long:"electrum-ssl" description:"whether the electrum server uses ssl"`
 	ElectrumLiquidUrl string `long:"electrum-liquid" description:"electrum rpc to use for fee estimations; set to empty string to disable"`
 	ElectrumLiquidSSL bool   `long:"electrum-liquid-ssl" description:"whether the electrum server uses ssl"`
-	Electrum          onchain.ElectrumConfig
 
 	Proxy string `long:"proxy" description:"Proxy URL to use for all Boltz API requests"`
 
 	Help *helpOptions `group:"Help Options"`
+}
+
+func (c *Config) Electrum() onchain.ElectrumConfig {
+	return onchain.ElectrumConfig{
+		Btc:    onchain.ElectrumOptions{Url: c.ElectrumUrl, SSL: c.ElectrumSSL},
+		Liquid: onchain.ElectrumOptions{Url: c.ElectrumLiquidUrl, SSL: c.ElectrumLiquidSSL},
+	}
 }
 
 func LoadConfig(dataDir string) (*Config, error) {
@@ -220,11 +226,6 @@ func LoadConfig(dataDir string) (*Config, error) {
 
 	createDirIfNotExists(cfg.DataDir)
 	createDirIfNotExists(macaroonDir)
-
-	cfg.Electrum = onchain.ElectrumConfig{
-		Btc:    onchain.ElectrumOptions{Url: cfg.ElectrumUrl, SSL: cfg.ElectrumSSL},
-		Liquid: onchain.ElectrumOptions{Url: cfg.ElectrumLiquidUrl, SSL: cfg.ElectrumLiquidSSL},
-	}
 
 	return &cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/BoltzExchange/boltz-client/onchain"
 	"os"
 	"path"
 	"runtime"
@@ -70,10 +71,7 @@ type Config struct {
 	MempoolApi       string `long:"mempool" description:"mempool.space API to use for fee estimations; set to empty string to disable"`
 	MempoolLiquidApi string `long:"mempool-liquid" description:"mempool.space liquid API to use for fee estimations; set to empty string to disable"`
 
-	ElectrumUrl            string `long:"electrum" description:"electrum rpc to use for fee estimations; set to empty string to disable"`
-	ElectrumSSL            bool   `long:"electrum-ssl" description:"whether the electrum server uses ssl"`
-	ElectrumLiquidUrl      string `long:"electrum-liquid" description:"electrum rpc to use for fee estimations; set to empty string to disable"`
-	ElectrumLiquiLiquidSSL bool   `long:"electrum-liquid-ssl" description:"whether the electrum server uses ssl"`
+	Electrum onchain.ElectrumConfig
 
 	Proxy string `long:"proxy" description:"Proxy URL to use for all Boltz API requests"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,11 @@ type Config struct {
 	MempoolApi       string `long:"mempool" description:"mempool.space API to use for fee estimations; set to empty string to disable"`
 	MempoolLiquidApi string `long:"mempool-liquid" description:"mempool.space liquid API to use for fee estimations; set to empty string to disable"`
 
-	Electrum onchain.ElectrumConfig
+	ElectrumUrl       string `long:"electrum" description:"electrum rpc to use for fee estimations; set to empty string to disable"`
+	ElectrumSSL       bool   `long:"electrum-ssl" description:"whether the electrum server uses ssl"`
+	ElectrumLiquidUrl string `long:"electrum-liquid" description:"electrum rpc to use for fee estimations; set to empty string to disable"`
+	ElectrumLiquidSSL bool   `long:"electrum-liquid-ssl" description:"whether the electrum server uses ssl"`
+	Electrum          onchain.ElectrumConfig
 
 	Proxy string `long:"proxy" description:"Proxy URL to use for all Boltz API requests"`
 
@@ -216,6 +220,11 @@ func LoadConfig(dataDir string) (*Config, error) {
 
 	createDirIfNotExists(cfg.DataDir)
 	createDirIfNotExists(macaroonDir)
+
+	cfg.Electrum = onchain.ElectrumConfig{
+		Btc:    onchain.ElectrumOptions{Url: cfg.ElectrumUrl, SSL: cfg.ElectrumSSL},
+		Liquid: onchain.ElectrumOptions{Url: cfg.ElectrumLiquidUrl, SSL: cfg.ElectrumLiquidSSL},
+	}
 
 	return &cfg, nil
 }

--- a/electrum/electrum.go
+++ b/electrum/electrum.go
@@ -17,15 +17,15 @@ type Client struct {
 	blockHeight uint32
 }
 
-func NewClient(url string, ssl bool) (*Client, error) {
+func NewClient(options onchain.ElectrumOptions) (*Client, error) {
 	// Establishing a new SSL connection to an ElectrumX server
 	ctx := context.Background()
 	c := &Client{ctx: ctx}
 	var err error
-	if ssl {
-		c.client, err = electrum.NewClientSSL(ctx, url, &tls.Config{})
+	if options.SSL {
+		c.client, err = electrum.NewClientSSL(ctx, options.Url, &tls.Config{})
 	} else {
-		c.client, err = electrum.NewClientTCP(ctx, url)
+		c.client, err = electrum.NewClientTCP(ctx, options.Url)
 	}
 	if err != nil {
 		return nil, err

--- a/electrum/electrum_test.go
+++ b/electrum/electrum_test.go
@@ -14,7 +14,7 @@ import (
 var url = "localhost:19001"
 
 func client(t *testing.T) *Client {
-	client, err := NewClient(url, false)
+	client, err := NewClient(onchain.RegtestElectrumConfig.Btc)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		client.Disconnect()

--- a/electrum/electrum_test.go
+++ b/electrum/electrum_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var url = "localhost:19001"
-
 func client(t *testing.T) *Client {
 	client, err := NewClient(onchain.RegtestElectrumConfig.Btc)
 	require.NoError(t, err)

--- a/onchain/onchain.go
+++ b/onchain/onchain.go
@@ -70,6 +70,21 @@ type Wallet interface {
 	Disconnect() error
 }
 
+type ElectrumOptions struct {
+	Url string `long:"url" description:"electrum rpc to use for fee estimations; set to empty string to disable"`
+	SSL bool   `long:"ssl" description:"whether the electrum server uses ssl"`
+}
+
+type ElectrumConfig struct {
+	Btc    ElectrumOptions `group:"Btc Electrum Options" namespace:"mempool.btc"`
+	Liquid ElectrumOptions `group:"Liquid Electrum Options" namespace:"mempool.liquid"`
+}
+
+var RegtestElectrumConfig = ElectrumConfig{
+	Btc:    ElectrumOptions{Url: "localhost:19001"},
+	Liquid: ElectrumOptions{Url: "localhost:19002"},
+}
+
 type Currency struct {
 	Blocks BlockProvider
 	Tx     TxProvider

--- a/onchain/onchain.go
+++ b/onchain/onchain.go
@@ -71,13 +71,13 @@ type Wallet interface {
 }
 
 type ElectrumOptions struct {
-	Url string `long:"url" description:"electrum rpc to use for fee estimations; set to empty string to disable"`
-	SSL bool   `long:"ssl" description:"whether the electrum server uses ssl"`
+	Url string
+	SSL bool
 }
 
 type ElectrumConfig struct {
-	Btc    ElectrumOptions `group:"Btc Electrum Options" namespace:"mempool.btc"`
-	Liquid ElectrumOptions `group:"Liquid Electrum Options" namespace:"mempool.liquid"`
+	Btc    ElectrumOptions
+	Liquid ElectrumOptions
 }
 
 var RegtestElectrumConfig = ElectrumConfig{

--- a/rpcserver/server.go
+++ b/rpcserver/server.go
@@ -352,12 +352,13 @@ func initOnchain(cfg *config.Config, boltzApi *boltz.Api, network *boltz.Network
 
 	chain.Init()
 
-	if cfg.Electrum.Liquid.Url == "" && cfg.MempoolLiquidApi == "" {
+	electrumConfig := cfg.Electrum()
+	if electrumConfig.Liquid.Url == "" && cfg.MempoolLiquidApi == "" {
 		chain.Liquid.Tx = onchain.NewBoltzTxProvider(boltzApi, boltz.CurrencyLiquid)
 	}
 
-	if network == boltz.Regtest && cfg.Electrum.Btc.Url == "" && cfg.Electrum.Liquid.Url == "" {
-		cfg.Electrum = onchain.RegtestElectrumConfig
+	if network == boltz.Regtest && electrumConfig.Btc.Url == "" && electrumConfig.Liquid.Url == "" {
+		electrumConfig = onchain.RegtestElectrumConfig
 	}
 
 	if !wallet.Initialized() {
@@ -365,25 +366,25 @@ func initOnchain(cfg *config.Config, boltzApi *boltz.Api, network *boltz.Network
 			DataDir:  cfg.DataDir,
 			Network:  network,
 			Debug:    false,
-			Electrum: cfg.Electrum,
+			Electrum: electrumConfig,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("could not init wallet: %v", err)
 		}
 	}
 
-	if cfg.Electrum.Btc.Url != "" {
-		logger.Info("Using configured Electrum BTC RPC: " + cfg.Electrum.Btc.Url)
-		client, err := electrum.NewClient(cfg.Electrum.Btc)
+	if electrumConfig.Btc.Url != "" {
+		logger.Info("Using configured Electrum BTC RPC: " + electrumConfig.Btc.Url)
+		client, err := electrum.NewClient(electrumConfig.Btc)
 		if err != nil {
 			return nil, fmt.Errorf("could not connect to electrum: %v", err)
 		}
 		chain.Btc.Blocks = client
 		chain.Btc.Tx = client
 	}
-	if cfg.Electrum.Liquid.Url != "" {
-		logger.Info("Using configured Electrum Liquid RPC: " + cfg.Electrum.Liquid.Url)
-		client, err := electrum.NewClient(cfg.Electrum.Liquid)
+	if electrumConfig.Liquid.Url != "" {
+		logger.Info("Using configured Electrum Liquid RPC: " + electrumConfig.Liquid.Url)
+		client, err := electrum.NewClient(electrumConfig.Liquid)
 		if err != nil {
 			return nil, fmt.Errorf("could not connect to electrum: %v", err)
 		}

--- a/rpcserver/server.go
+++ b/rpcserver/server.go
@@ -373,7 +373,7 @@ func initOnchain(cfg *config.Config, boltzApi *boltz.Api, network *boltz.Network
 	}
 
 	if cfg.Electrum.Btc.Url != "" {
-		logger.Info("Using configured Electrum Btc RPC: " + cfg.Electrum.Btc.Url)
+		logger.Info("Using configured Electrum BTC RPC: " + cfg.Electrum.Btc.Url)
 		client, err := electrum.NewClient(cfg.Electrum.Btc)
 		if err != nil {
 			return nil, fmt.Errorf("could not connect to electrum: %v", err)

--- a/rpcserver/server.go
+++ b/rpcserver/server.go
@@ -352,33 +352,38 @@ func initOnchain(cfg *config.Config, boltzApi *boltz.Api, network *boltz.Network
 
 	chain.Init()
 
-	if cfg.ElectrumLiquidUrl == "" && cfg.MempoolLiquidApi == "" {
+	if cfg.Electrum.Liquid.Url == "" && cfg.MempoolLiquidApi == "" {
 		chain.Liquid.Tx = onchain.NewBoltzTxProvider(boltzApi, boltz.CurrencyLiquid)
+	}
+
+	if network == boltz.Regtest && cfg.Electrum.Btc.Url == "" && cfg.Electrum.Liquid.Url == "" {
+		cfg.Electrum = onchain.RegtestElectrumConfig
 	}
 
 	if !wallet.Initialized() {
 		err := wallet.Init(wallet.Config{
-			DataDir: cfg.DataDir,
-			Network: network,
-			Debug:   false,
+			DataDir:  cfg.DataDir,
+			Network:  network,
+			Debug:    false,
+			Electrum: cfg.Electrum,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("could not init wallet: %v", err)
 		}
 	}
 
-	if cfg.ElectrumUrl != "" {
-		logger.Info("Using configured Electrum RPC: " + cfg.ElectrumUrl)
-		client, err := electrum.NewClient(cfg.ElectrumUrl, cfg.ElectrumSSL)
+	if cfg.Electrum.Btc.Url != "" {
+		logger.Info("Using configured Electrum Btc RPC: " + cfg.Electrum.Btc.Url)
+		client, err := electrum.NewClient(cfg.Electrum.Btc)
 		if err != nil {
 			return nil, fmt.Errorf("could not connect to electrum: %v", err)
 		}
 		chain.Btc.Blocks = client
 		chain.Btc.Tx = client
 	}
-	if cfg.ElectrumLiquidUrl != "" {
-		logger.Info("Using configured Electrum Liquid RPC: " + cfg.ElectrumLiquidUrl)
-		client, err := electrum.NewClient(cfg.ElectrumLiquidUrl, cfg.ElectrumLiquiLiquidSSL)
+	if cfg.Electrum.Liquid.Url != "" {
+		logger.Info("Using configured Electrum Liquid RPC: " + cfg.Electrum.Liquid.Url)
+		client, err := electrum.NewClient(cfg.Electrum.Liquid)
 		if err != nil {
 			return nil, fmt.Errorf("could not connect to electrum: %v", err)
 		}

--- a/rpcserver/test/boltz.toml
+++ b/rpcserver/test/boltz.toml
@@ -1,6 +1,3 @@
-electrumUrl = "localhost:19001"
-electrumLiquidUrl = "localhost:19002"
-
 network = "regtest"
 
 [LND]

--- a/test/test.go
+++ b/test/test.go
@@ -38,9 +38,10 @@ func InitTestWallet(currency boltz.Currency, debug bool) (*wallet.Wallet, *walle
 	InitLogger()
 	if !wallet.Initialized() {
 		err = wallet.Init(wallet.Config{
-			DataDir: "./test-data",
-			Network: boltz.Regtest,
-			Debug:   debug,
+			DataDir:  "./test-data",
+			Network:  boltz.Regtest,
+			Debug:    debug,
+			Electrum: onchain.RegtestElectrumConfig,
 		})
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
The GDK defaults (or the localhost urls for regtest) were always used before.
This is a breaking change to the config but I doubt that there are existing setups that use custom electrum servers.