### PR TITLE
fix: check for duplicate wallet names

### DIFF
--- a/rpcserver/router.go
+++ b/rpcserver/router.go
@@ -1283,12 +1283,15 @@ func (server *routedBoltzServer) loginWallet(credentials *wallet.Credentials) (*
 func (server *routedBoltzServer) importWallet(ctx context.Context, credentials *wallet.Credentials, password string) error {
 	decryptWalletCredentials, err := server.decryptWalletCredentials(password)
 	if err != nil {
-		return errors.New("wrong password")
+		return status.Error(codes.InvalidArgument, "wrong password")
 	}
 
 	for _, existing := range decryptWalletCredentials {
+		if existing.Name == credentials.Name && existing.TenantId == credentials.TenantId {
+			return status.Errorf(codes.InvalidArgument, "wallet %s already exists", existing.Name)
+		}
 		if existing.Mnemonic == credentials.Mnemonic && existing.Xpub == credentials.Xpub && existing.CoreDescriptor == credentials.CoreDescriptor {
-			return fmt.Errorf("wallet %s has the same credentials", existing.Name)
+			return status.Errorf(codes.InvalidArgument, "wallet %s has the same credentials", existing.Name)
 		}
 	}
 

--- a/rpcserver/rpcserver_test.go
+++ b/rpcserver/rpcserver_test.go
@@ -2156,26 +2156,33 @@ func TestMagicRoutingHints(t *testing.T) {
 	}
 }
 
-func TestCreateWalletWithPassword(t *testing.T) {
+func TestCreateWallet(t *testing.T) {
 	client, _, stop := setup(t, setupOptions{})
 	defer stop()
 
-	_, err := client.GetWalletCredentials(testWallet.Id, nil)
-	require.NoError(t, err)
+	t.Run("WithPassword", func(t *testing.T) {
+		_, err := client.GetWalletCredentials(testWallet.Id, nil)
+		require.NoError(t, err)
 
-	// after creating one with a password, the first one will be encrypted as well
-	secondParams := &boltzrpc.WalletParams{Name: "another", Currency: boltzrpc.Currency_BTC, Password: &password}
-	secondWallet, err := client.CreateWallet(secondParams)
-	require.NoError(t, err)
+		// after creating one with a password, the first one will be encrypted as well
+		secondParams := &boltzrpc.WalletParams{Name: "another", Currency: boltzrpc.Currency_BTC, Password: &password}
+		secondWallet, err := client.CreateWallet(secondParams)
+		require.NoError(t, err)
 
-	_, err = client.GetWalletCredentials(testWallet.Id, nil)
-	require.Error(t, err)
+		_, err = client.GetWalletCredentials(testWallet.Id, nil)
+		require.Error(t, err)
 
-	_, err = client.GetWalletCredentials(testWallet.Id, &password)
-	require.NoError(t, err)
+		_, err = client.GetWalletCredentials(testWallet.Id, &password)
+		require.NoError(t, err)
 
-	_, err = client.RemoveWallet(secondWallet.Wallet.Id)
-	require.NoError(t, err)
+		_, err = client.RemoveWallet(secondWallet.Wallet.Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("DuplicateName", func(t *testing.T) {
+		_, err := client.CreateWallet(&boltzrpc.WalletParams{Name: walletName, Currency: boltzrpc.Currency_BTC})
+		require.Error(t, err)
+	})
 
 }
 


### PR DESCRIPTION
The sqlite unique constraint ignores NULL values, so we do a check in go.