### PR TITLE
test: make sure swap stream runs when mining block

### DIFF
--- a/rpcserver/rpcserver_test.go
+++ b/rpcserver/rpcserver_test.go
@@ -1835,8 +1835,8 @@ func TestAutoSwap(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, recommendations.Chain, 1)
 
-		test.MineBlock()
 		stream, _ := swapStream(t, admin, "")
+		test.MineBlock()
 		info := stream(boltzrpc.SwapState_PENDING)
 		require.NotNil(t, info.ChainSwap)
 		id := info.ChainSwap.Id


### PR DESCRIPTION
it seems like the stream starts too late sometimes, causing the updates
to be missed
