### PR TITLE
refactor: increase default ln autoswap reserve to 10 percent

### DIFF
--- a/autoswap/lightning.go
+++ b/autoswap/lightning.go
@@ -35,8 +35,10 @@ type LightningConfig struct {
 	walletId        *database.Id
 }
 
+const DefaultReserve = boltz.Percentage(10)
+
 func NewLightningConfig(serialized *SerializedLnConfig, shared shared) *LightningConfig {
-	return &LightningConfig{SerializedLnConfig: withLightningBase(serialized), shared: shared, reserve: boltz.Percentage(2)}
+	return &LightningConfig{SerializedLnConfig: withLightningBase(serialized), shared: shared, reserve: DefaultReserve}
 }
 
 func withLightningBase(config *SerializedLnConfig) *SerializedLnConfig {


### PR DESCRIPTION
we shouldnt try to swap out all inbound balance, so there is still
balance left for payments
