### PR TITLE
fix: decrease `MaxInputs` by 1

### DIFF
--- a/onchain/wallet/wallet.go
+++ b/onchain/wallet/wallet.go
@@ -33,7 +33,7 @@ import (
 )
 
 const MinFeeRate = 0.01
-const MaxInputs = uint64(256)
+const MaxInputs = uint64(255) // TODO: change back to 256 when gdk is fixed
 const DefaultAutoConsolidateThreshold = uint64(200)
 const GapLimit = 100
 


### PR DESCRIPTION
gdk started to impose their own limit which is off by 1
