### PR TITLE
fix: dont include lightning lib in cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build: download-gdk build-bolt12
 static: download-gdk build-bolt12
 	@$(call print, "Building static boltz-client")
 	$(GOBUILD) -tags static -o boltzd $(LDFLAGS) $(PKG_BOLTZD)
-	$(GOBUILD) -o boltzcli $(LDFLAGS) $(PKG_BOLTZ_CLI)
+	$(GOBUILD) -tags static -o boltzcli $(LDFLAGS) $(PKG_BOLTZ_CLI)
 
 
 daemon:

--- a/autoswap/lightning.go
+++ b/autoswap/lightning.go
@@ -337,7 +337,7 @@ func (cfg *LightningConfig) getSwapRecommendations(includeAll bool) ([]*autoswap
 	for _, recommendation := range validated {
 		result = append(result, &autoswaprpc.LightningRecommendation{
 			Swap:       serializeLightningSwap(recommendation.Swap),
-			Channel:    serializers.SerializeLightningChannel(recommendation.Channel),
+			Channel:    serializeLightningChannel(recommendation.Channel),
 			Thresholds: recommendation.Thresholds,
 		})
 	}

--- a/autoswap/rpc.go
+++ b/autoswap/rpc.go
@@ -1,9 +1,24 @@
 package autoswap
 
 import (
+	"github.com/BoltzExchange/boltz-client/boltzrpc"
 	"github.com/BoltzExchange/boltz-client/boltzrpc/autoswaprpc"
 	"github.com/BoltzExchange/boltz-client/boltzrpc/serializers"
+	"github.com/BoltzExchange/boltz-client/lightning"
 )
+
+func serializeLightningChannel(channel *lightning.LightningChannel) *boltzrpc.LightningChannel {
+	if channel == nil {
+		return nil
+	}
+	return &boltzrpc.LightningChannel{
+		Id:          lightning.SerializeChanId(channel.Id),
+		Capacity:    channel.Capacity,
+		OutboundSat: channel.OutboundSat,
+		InboundSat:  channel.InboundSat,
+		PeerId:      channel.PeerId,
+	}
+}
 
 func serializeLightningSwap(swap *LightningSwap) *autoswaprpc.LightningSwap {
 	if swap == nil {

--- a/boltzrpc/serializers/utils.go
+++ b/boltzrpc/serializers/utils.go
@@ -3,7 +3,6 @@ package serializers
 import (
 	"github.com/BoltzExchange/boltz-client/boltz"
 	"github.com/BoltzExchange/boltz-client/boltzrpc"
-	"github.com/BoltzExchange/boltz-client/lightning"
 	"github.com/BoltzExchange/boltz-client/onchain"
 )
 
@@ -52,35 +51,6 @@ func SerializePair(pair boltz.Pair) *boltzrpc.Pair {
 	}
 }
 
-func SerializeChanId(chanId lightning.ChanId) *boltzrpc.ChannelId {
-	if chanId != 0 {
-		return &boltzrpc.ChannelId{
-			Cln: chanId.ToCln(),
-			Lnd: chanId.ToLnd(),
-		}
-	}
-	return nil
-}
-
-func SerializeChanIds(chanIds []lightning.ChanId) (result []*boltzrpc.ChannelId) {
-	for _, chanId := range chanIds {
-		result = append(result, SerializeChanId(chanId))
-	}
-	return result
-}
-
-func SerializeLightningChannel(channel *lightning.LightningChannel) *boltzrpc.LightningChannel {
-	if channel == nil {
-		return nil
-	}
-	return &boltzrpc.LightningChannel{
-		Id:          SerializeChanId(channel.Id),
-		Capacity:    channel.Capacity,
-		OutboundSat: channel.OutboundSat,
-		InboundSat:  channel.InboundSat,
-		PeerId:      channel.PeerId,
-	}
-}
 func SerializeWalletBalance(balance *onchain.Balance) *boltzrpc.Balance {
 	if balance == nil {
 		return nil

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -3,6 +3,7 @@ package lightning
 import (
 	"context"
 	"errors"
+	"github.com/BoltzExchange/boltz-client/boltzrpc"
 	"github.com/BoltzExchange/boltz-client/onchain"
 )
 
@@ -97,4 +98,21 @@ type LightningNode interface {
 	ConnectPeer(uri string) error
 
 	SetupWallet(info onchain.WalletInfo)
+}
+
+func SerializeChanId(chanId ChanId) *boltzrpc.ChannelId {
+	if chanId != 0 {
+		return &boltzrpc.ChannelId{
+			Cln: chanId.ToCln(),
+			Lnd: chanId.ToLnd(),
+		}
+	}
+	return nil
+}
+
+func SerializeChanIds(chanIds []ChanId) (result []*boltzrpc.ChannelId) {
+	for _, chanId := range chanIds {
+		result = append(result, SerializeChanId(chanId))
+	}
+	return result
 }

--- a/rpcserver/serializer.go
+++ b/rpcserver/serializer.go
@@ -2,6 +2,7 @@ package rpcserver
 
 import (
 	"github.com/BoltzExchange/boltz-client/boltzrpc/serializers"
+	"github.com/BoltzExchange/boltz-client/lightning"
 	"time"
 
 	"github.com/BoltzExchange/boltz-client/boltz"
@@ -44,7 +45,7 @@ func serializeSwap(swap *database.Swap) *boltzrpc.SwapInfo {
 	serialized := &boltzrpc.SwapInfo{
 		Id:                  serializedSwap.Id,
 		Pair:                serializePair(swap.Pair),
-		ChanIds:             serializers.SerializeChanIds(swap.ChanIds),
+		ChanIds:             lightning.SerializeChanIds(swap.ChanIds),
 		State:               swap.State,
 		Error:               serializedSwap.Error,
 		Status:              serializedSwap.Status,
@@ -104,7 +105,7 @@ func serializeReverseSwap(reverseSwap *database.ReverseSwap) *boltzrpc.ReverseSw
 	return &boltzrpc.ReverseSwapInfo{
 		Id:                  serializedReverseSwap.Id,
 		Pair:                serializePair(reverseSwap.Pair),
-		ChanIds:             serializers.SerializeChanIds(reverseSwap.ChanIds),
+		ChanIds:             lightning.SerializeChanIds(reverseSwap.ChanIds),
 		State:               reverseSwap.State,
 		Error:               serializedReverseSwap.Error,
 		Status:              serializedReverseSwap.Status,


### PR DESCRIPTION
The cli accidently became dependant on the `lightning` package which links to the bolt12 rust lib.

This shouldn't be the case, so this PR moves some serializers to get rid of that dependancy aswell as adding the -static tag to the cli build command to make sure this doesn't happen again.

Not very happy with the current situation, as its easy to mess up.