### PR TITLE
fix: remove timeout block height from claimable swaps query

### DIFF
--- a/database/chain.go
+++ b/database/chain.go
@@ -325,12 +325,11 @@ FROM chainSwaps swaps
 WHERE data.lockupTransactionId != ''
   AND data.transactionId == ''
   AND state != ? 
-  AND data.timeoutBlockheight > ?
 `
 
-func (database *Database) QueryClaimableChainSwaps(tenantId *Id, currency boltz.Currency, currentBlockHeight uint32) ([]*ChainSwap, error) {
+func (database *Database) QueryClaimableChainSwaps(tenantId *Id, currency boltz.Currency) ([]*ChainSwap, error) {
 	query := claimableChainSwapsQuery
-	values := []any{currency, boltzrpc.SwapState_REFUNDED, currentBlockHeight}
+	values := []any{currency, boltzrpc.SwapState_REFUNDED}
 	if tenantId != nil {
 		query += " AND tenantId = ?"
 		values = append(values, tenantId)

--- a/database/database.go
+++ b/database/database.go
@@ -480,12 +480,12 @@ func (database *Database) QueryAllRefundableSwaps(tenantId *Id, currency boltz.C
 	return swaps, chainSwaps, nil
 }
 
-func (database *Database) QueryAllClaimableSwaps(tenantId *Id, currency boltz.Currency, currentHeight uint32) ([]*ReverseSwap, []*ChainSwap, error) {
-	reverseSwaps, err := database.QueryClaimableReverseSwaps(tenantId, currency, currentHeight)
+func (database *Database) QueryAllClaimableSwaps(tenantId *Id, currency boltz.Currency) ([]*ReverseSwap, []*ChainSwap, error) {
+	reverseSwaps, err := database.QueryClaimableReverseSwaps(tenantId, currency)
 	if err != nil {
 		return nil, nil, err
 	}
-	chainSwaps, err := database.QueryClaimableChainSwaps(tenantId, currency, currentHeight)
+	chainSwaps, err := database.QueryClaimableChainSwaps(tenantId, currency)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/database/reverse.go
+++ b/database/reverse.go
@@ -270,12 +270,11 @@ SELECT * FROM reverseSwaps
 WHERE fromCurrency = ?
   AND reverseSwaps.lockupTransactionId != ''
   AND reverseSwaps.claimTransactionId == ''
-  AND reverseSwaps.timeoutBlockheight > ?
 `
 
-func (database *Database) QueryClaimableReverseSwaps(tenantId *Id, currency boltz.Currency, currentBlockHeight uint32) ([]*ReverseSwap, error) {
+func (database *Database) QueryClaimableReverseSwaps(tenantId *Id, currency boltz.Currency) ([]*ReverseSwap, error) {
 	query := claimableSwapsQuery
-	values := []any{currency, currentBlockHeight}
+	values := []any{currency}
 	if tenantId != nil {
 		query += " AND tenantId = ?"
 		values = append(values, *tenantId)


### PR DESCRIPTION
No need to check timeout when looking for claimable swaps - if they already timed out its even more urgent to claim.