### PR TITLE
fix: legacy `getpairs` request

### DIFF
--- a/pkg/boltz/api.go
+++ b/pkg/boltz/api.go
@@ -408,7 +408,7 @@ func (boltz *Api) GetVersion() (*GetVersionResponse, error) {
 // Deprecated: use GetSubmarinePairs, GetChainPairs or GetReversePairs instead
 func (boltz *Api) GetPairs() (*GetPairsResponse, error) {
 	var response GetPairsResponse
-	err := boltz.sendGetRequestV2("/getpairs", &response)
+	err := boltz.sendGetRequest("/getpairs", &response)
 
 	return &response, err
 }


### PR DESCRIPTION
regression was introduce in: https://github.com/BoltzExchange/boltz-client/commit/c9930d072ed26fcc0462eaa449297ab634dc579b
