### PR TITLE
docs: fix rest annotations link

### DIFF
--- a/pkg/boltzrpc/grpc_docs.template
+++ b/pkg/boltzrpc/grpc_docs.template
@@ -2,7 +2,7 @@
 
 This page was automatically generated.
 
-Paths for the REST proxy of the gRPC interface can be found [here](https://github.com/BoltzExchange/boltz-client/blob/master/boltzrpc/rest-annotations.yaml).
+Paths for the REST proxy of the gRPC interface can be found [here](https://github.com/BoltzExchange/boltz-client/blob/master/pkg/boltzrpc/rest-annotations.yaml).
 
 {{range .Files}}
 {{$file_name := .Name}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the REST proxy URL in the gRPC interface documentation to reflect the new location of the REST annotations file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->