### PR TITLE
docs: add pro option in sample config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,9 @@ network = "mainnet"
 # you will have to set this to "cln" or "lnd" if you have configuration values for both
 node = ""
 
+# Whether to use Boltz Pro fee rates
+pro = false
+
 [BOLTZ]
 # By default the daemon automatically connects to the official Boltz Backend for the network your node is on
 # This value is used to overwrite that


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added information about a new configuration option `pro`, which determines whether Boltz Pro fee rates are used. The default value is `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->