### PR TITLE
docs: standalone mode

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,10 @@ The daemon connects to CLN through [gRPC](https://docs.corelightning.org/docs/gr
 You can manually set the paths of `cln.rootcert`, `cln.privatekey` and `cln.certchain` instead of speciyfing the data directory as well.
 You might have to set the `cln.servername` option as well, if you are using a custom certificate.
 
+#### Standalone
+
+The daemon can also operate without a lightning node. In this case, you need to specify the `--standalone` CLI flag or set the `standalone` option to `true` in the configuration file.
+
 ### CLI
 
 We recommend running `boltzcli completions` to setup autocompletions for the CLI (only supported for zsh and bash).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,9 @@ node = ""
 # Whether to use Boltz Pro fee rates
 pro = false
 
+# The daemon can also operate without a lightning node
+# standalone = true
+
 [BOLTZ]
 # By default the daemon automatically connects to the official Boltz Backend for the network your node is on
 # This value is used to overwrite that


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to describe a new "Standalone" mode for the daemon, allowing operation without a lightning node.
  - Added instructions for enabling standalone mode via CLI flag or configuration file setting.
  - Provided example configuration and clarified usage in the configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->