### PR TITLE
fix: save preimage for every swap

### DIFF
--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -2126,6 +2126,7 @@ func TestSwap(t *testing.T) {
 		invoice, err := zpay32.Decode(swap.Invoice, &chaincfg.RegressionNetParams)
 		require.NoError(t, err)
 		preimage, err := hex.DecodeString(swap.Preimage)
+		require.NotEmpty(t, swap.Preimage)
 		require.NoError(t, err)
 		require.Equal(t, *invoice.PaymentHash, sha256.Sum256(preimage))
 

--- a/pkg/boltz/api.go
+++ b/pkg/boltz/api.go
@@ -485,6 +485,15 @@ func (boltz *Api) GetSwapTransaction(id string) (*GetSwapTransactionResponse, er
 	return &response, err
 }
 
+func (boltz *Api) GetSwapPreimage(id string) (HexString, error) {
+	var response struct {
+		Preimage HexString `json:"preimage"`
+	}
+	err := boltz.sendGetRequestV2(fmt.Sprintf("/swap/submarine/%s/preimage", id), &response)
+
+	return response.Preimage, err
+}
+
 func (boltz *Api) GetChainSwapTransactions(id string) (*GetChainSwapTransactionsResponse, error) {
 	var response GetChainSwapTransactionsResponse
 	path := fmt.Sprintf("/swap/chain/%s/transactions", id)


### PR DESCRIPTION
follow up on #446 
previously only saved on cooperative claims - but thats not the case for every swap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve and validate swap preimages automatically during swap finalization.
- **Bug Fixes**
  - Improved test reliability by ensuring swap preimages are present before running assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->