### PR TITLE
refactor: improve wallet interface

### DIFF
--- a/internal/cln/cln.go
+++ b/internal/cln/cln.go
@@ -325,22 +325,22 @@ func (c *Cln) GetBalance() (*onchain.Balance, error) {
 	return balance, err
 }
 
-func (c *Cln) SendToAddress(address string, amount uint64, satPerVbyte float64, sendAll bool) (string, error) {
+func (c *Cln) SendToAddress(args onchain.WalletSendArgs) (string, error) {
 	request := &protos.WithdrawRequest{
-		Destination: address,
+		Destination: args.Address,
 		Satoshi:     &protos.AmountOrAll{},
 		Feerate: &protos.Feerate{
 			Style: &protos.Feerate_Perkb{
 				// TODO: check this is correct
-				Perkb: uint32(satPerVbyte * 1000),
+				Perkb: uint32(args.SatPerVbyte * 1000),
 			},
 		},
 	}
-	if sendAll {
+	if args.SendAll {
 		request.Satoshi.Value = &protos.AmountOrAll_All{All: true}
 	} else {
 		request.Satoshi.Value = &protos.AmountOrAll_Amount{Amount: &protos.Amount{
-			Msat: amount * 1000,
+			Msat: args.Amount * 1000,
 		}}
 	}
 
@@ -352,6 +352,10 @@ func (c *Cln) SendToAddress(address string, amount uint64, satPerVbyte float64, 
 
 	return hex.EncodeToString(response.GetTxid()), nil
 
+}
+
+func (c *Cln) GetSendFee(args onchain.WalletSendArgs) (send uint64, fee uint64, err error) {
+	return 0, 0, lightning.ErrUnsupported
 }
 
 func encodeOptionalBytes(data []byte) string {

--- a/internal/lnd/lnd.go
+++ b/internal/lnd/lnd.go
@@ -382,12 +382,12 @@ func (lnd *LND) GetBalance() (*onchain.Balance, error) {
 
 }
 
-func (lnd *LND) SendToAddress(address string, amount uint64, satPerVbyte float64, sendAll bool) (string, error) {
+func (lnd *LND) SendToAddress(args onchain.WalletSendArgs) (string, error) {
 	response, err := lnd.client.SendCoins(lnd.ctx, &lnrpc.SendCoinsRequest{
-		Addr:        address,
-		Amount:      int64(amount),
-		SatPerVbyte: uint64(satPerVbyte),
-		SendAll:     sendAll,
+		Addr:        args.Address,
+		Amount:      int64(args.Amount),
+		SatPerVbyte: uint64(args.SatPerVbyte),
+		SendAll:     args.SendAll,
 	})
 
 	if err != nil {
@@ -395,6 +395,10 @@ func (lnd *LND) SendToAddress(address string, amount uint64, satPerVbyte float64
 	}
 
 	return response.Txid, nil
+}
+
+func (lnd *LND) GetSendFee(args onchain.WalletSendArgs) (send uint64, fee uint64, err error) {
+	return 0, 0, lightning.ErrUnsupported
 }
 
 func (lnd *LND) SubscribeSingleInvoice(preimageHash []byte, channel chan *lnrpc.Invoice, errChannel chan error) {

--- a/internal/mocks/lightning/LightningNode_mock.go
+++ b/internal/mocks/lightning/LightningNode_mock.go
@@ -443,6 +443,72 @@ func (_c *MockLightningNode_GetInfo_Call) RunAndReturn(run func() (*lightning.Li
 	return _c
 }
 
+// GetSendFee provides a mock function for the type MockLightningNode
+func (_mock *MockLightningNode) GetSendFee(args onchain.WalletSendArgs) (uint64, uint64, error) {
+	ret := _mock.Called(args)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSendFee")
+	}
+
+	var r0 uint64
+	var r1 uint64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) (uint64, uint64, error)); ok {
+		return returnFunc(args)
+	}
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) uint64); ok {
+		r0 = returnFunc(args)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(onchain.WalletSendArgs) uint64); ok {
+		r1 = returnFunc(args)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(onchain.WalletSendArgs) error); ok {
+		r2 = returnFunc(args)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockLightningNode_GetSendFee_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSendFee'
+type MockLightningNode_GetSendFee_Call struct {
+	*mock.Call
+}
+
+// GetSendFee is a helper method to define mock.On call
+//   - args onchain.WalletSendArgs
+func (_e *MockLightningNode_Expecter) GetSendFee(args interface{}) *MockLightningNode_GetSendFee_Call {
+	return &MockLightningNode_GetSendFee_Call{Call: _e.mock.On("GetSendFee", args)}
+}
+
+func (_c *MockLightningNode_GetSendFee_Call) Run(run func(args onchain.WalletSendArgs)) *MockLightningNode_GetSendFee_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 onchain.WalletSendArgs
+		if args[0] != nil {
+			arg0 = args[0].(onchain.WalletSendArgs)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockLightningNode_GetSendFee_Call) Return(send uint64, fee uint64, err error) *MockLightningNode_GetSendFee_Call {
+	_c.Call.Return(send, fee, err)
+	return _c
+}
+
+func (_c *MockLightningNode_GetSendFee_Call) RunAndReturn(run func(args onchain.WalletSendArgs) (uint64, uint64, error)) *MockLightningNode_GetSendFee_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTransactions provides a mock function for the type MockLightningNode
 func (_mock *MockLightningNode) GetTransactions(limit uint64, offset uint64) ([]*onchain.WalletTransaction, error) {
 	ret := _mock.Called(limit, offset)
@@ -900,8 +966,8 @@ func (_c *MockLightningNode_Ready_Call) RunAndReturn(run func() bool) *MockLight
 }
 
 // SendToAddress provides a mock function for the type MockLightningNode
-func (_mock *MockLightningNode) SendToAddress(address string, amount uint64, satPerVbyte float64, sendAll bool) (string, error) {
-	ret := _mock.Called(address, amount, satPerVbyte, sendAll)
+func (_mock *MockLightningNode) SendToAddress(args onchain.WalletSendArgs) (string, error) {
+	ret := _mock.Called(args)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendToAddress")
@@ -909,16 +975,16 @@ func (_mock *MockLightningNode) SendToAddress(address string, amount uint64, sat
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, uint64, float64, bool) (string, error)); ok {
-		return returnFunc(address, amount, satPerVbyte, sendAll)
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) (string, error)); ok {
+		return returnFunc(args)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, uint64, float64, bool) string); ok {
-		r0 = returnFunc(address, amount, satPerVbyte, sendAll)
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) string); ok {
+		r0 = returnFunc(args)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, uint64, float64, bool) error); ok {
-		r1 = returnFunc(address, amount, satPerVbyte, sendAll)
+	if returnFunc, ok := ret.Get(1).(func(onchain.WalletSendArgs) error); ok {
+		r1 = returnFunc(args)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -931,37 +997,19 @@ type MockLightningNode_SendToAddress_Call struct {
 }
 
 // SendToAddress is a helper method to define mock.On call
-//   - address string
-//   - amount uint64
-//   - satPerVbyte float64
-//   - sendAll bool
-func (_e *MockLightningNode_Expecter) SendToAddress(address interface{}, amount interface{}, satPerVbyte interface{}, sendAll interface{}) *MockLightningNode_SendToAddress_Call {
-	return &MockLightningNode_SendToAddress_Call{Call: _e.mock.On("SendToAddress", address, amount, satPerVbyte, sendAll)}
+//   - args onchain.WalletSendArgs
+func (_e *MockLightningNode_Expecter) SendToAddress(args interface{}) *MockLightningNode_SendToAddress_Call {
+	return &MockLightningNode_SendToAddress_Call{Call: _e.mock.On("SendToAddress", args)}
 }
 
-func (_c *MockLightningNode_SendToAddress_Call) Run(run func(address string, amount uint64, satPerVbyte float64, sendAll bool)) *MockLightningNode_SendToAddress_Call {
+func (_c *MockLightningNode_SendToAddress_Call) Run(run func(args onchain.WalletSendArgs)) *MockLightningNode_SendToAddress_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 onchain.WalletSendArgs
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 uint64
-		if args[1] != nil {
-			arg1 = args[1].(uint64)
-		}
-		var arg2 float64
-		if args[2] != nil {
-			arg2 = args[2].(float64)
-		}
-		var arg3 bool
-		if args[3] != nil {
-			arg3 = args[3].(bool)
+			arg0 = args[0].(onchain.WalletSendArgs)
 		}
 		run(
 			arg0,
-			arg1,
-			arg2,
-			arg3,
 		)
 	})
 	return _c
@@ -972,7 +1020,7 @@ func (_c *MockLightningNode_SendToAddress_Call) Return(s string, err error) *Moc
 	return _c
 }
 
-func (_c *MockLightningNode_SendToAddress_Call) RunAndReturn(run func(address string, amount uint64, satPerVbyte float64, sendAll bool) (string, error)) *MockLightningNode_SendToAddress_Call {
+func (_c *MockLightningNode_SendToAddress_Call) RunAndReturn(run func(args onchain.WalletSendArgs) (string, error)) *MockLightningNode_SendToAddress_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/mocks/onchain/Wallet_mock.go
+++ b/internal/mocks/onchain/Wallet_mock.go
@@ -201,6 +201,72 @@ func (_c *MockWallet_GetBalance_Call) RunAndReturn(run func() (*onchain.Balance,
 	return _c
 }
 
+// GetSendFee provides a mock function for the type MockWallet
+func (_mock *MockWallet) GetSendFee(args onchain.WalletSendArgs) (uint64, uint64, error) {
+	ret := _mock.Called(args)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSendFee")
+	}
+
+	var r0 uint64
+	var r1 uint64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) (uint64, uint64, error)); ok {
+		return returnFunc(args)
+	}
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) uint64); ok {
+		r0 = returnFunc(args)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(onchain.WalletSendArgs) uint64); ok {
+		r1 = returnFunc(args)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(onchain.WalletSendArgs) error); ok {
+		r2 = returnFunc(args)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockWallet_GetSendFee_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSendFee'
+type MockWallet_GetSendFee_Call struct {
+	*mock.Call
+}
+
+// GetSendFee is a helper method to define mock.On call
+//   - args onchain.WalletSendArgs
+func (_e *MockWallet_Expecter) GetSendFee(args interface{}) *MockWallet_GetSendFee_Call {
+	return &MockWallet_GetSendFee_Call{Call: _e.mock.On("GetSendFee", args)}
+}
+
+func (_c *MockWallet_GetSendFee_Call) Run(run func(args onchain.WalletSendArgs)) *MockWallet_GetSendFee_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 onchain.WalletSendArgs
+		if args[0] != nil {
+			arg0 = args[0].(onchain.WalletSendArgs)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWallet_GetSendFee_Call) Return(send uint64, fee uint64, err error) *MockWallet_GetSendFee_Call {
+	_c.Call.Return(send, fee, err)
+	return _c
+}
+
+func (_c *MockWallet_GetSendFee_Call) RunAndReturn(run func(args onchain.WalletSendArgs) (uint64, uint64, error)) *MockWallet_GetSendFee_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTransactions provides a mock function for the type MockWallet
 func (_mock *MockWallet) GetTransactions(limit uint64, offset uint64) ([]*onchain.WalletTransaction, error) {
 	ret := _mock.Called(limit, offset)
@@ -411,8 +477,8 @@ func (_c *MockWallet_Ready_Call) RunAndReturn(run func() bool) *MockWallet_Ready
 }
 
 // SendToAddress provides a mock function for the type MockWallet
-func (_mock *MockWallet) SendToAddress(address string, amount uint64, satPerVbyte float64, sendAll bool) (string, error) {
-	ret := _mock.Called(address, amount, satPerVbyte, sendAll)
+func (_mock *MockWallet) SendToAddress(args onchain.WalletSendArgs) (string, error) {
+	ret := _mock.Called(args)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SendToAddress")
@@ -420,16 +486,16 @@ func (_mock *MockWallet) SendToAddress(address string, amount uint64, satPerVbyt
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, uint64, float64, bool) (string, error)); ok {
-		return returnFunc(address, amount, satPerVbyte, sendAll)
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) (string, error)); ok {
+		return returnFunc(args)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, uint64, float64, bool) string); ok {
-		r0 = returnFunc(address, amount, satPerVbyte, sendAll)
+	if returnFunc, ok := ret.Get(0).(func(onchain.WalletSendArgs) string); ok {
+		r0 = returnFunc(args)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, uint64, float64, bool) error); ok {
-		r1 = returnFunc(address, amount, satPerVbyte, sendAll)
+	if returnFunc, ok := ret.Get(1).(func(onchain.WalletSendArgs) error); ok {
+		r1 = returnFunc(args)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -442,37 +508,19 @@ type MockWallet_SendToAddress_Call struct {
 }
 
 // SendToAddress is a helper method to define mock.On call
-//   - address string
-//   - amount uint64
-//   - satPerVbyte float64
-//   - sendAll bool
-func (_e *MockWallet_Expecter) SendToAddress(address interface{}, amount interface{}, satPerVbyte interface{}, sendAll interface{}) *MockWallet_SendToAddress_Call {
-	return &MockWallet_SendToAddress_Call{Call: _e.mock.On("SendToAddress", address, amount, satPerVbyte, sendAll)}
+//   - args onchain.WalletSendArgs
+func (_e *MockWallet_Expecter) SendToAddress(args interface{}) *MockWallet_SendToAddress_Call {
+	return &MockWallet_SendToAddress_Call{Call: _e.mock.On("SendToAddress", args)}
 }
 
-func (_c *MockWallet_SendToAddress_Call) Run(run func(address string, amount uint64, satPerVbyte float64, sendAll bool)) *MockWallet_SendToAddress_Call {
+func (_c *MockWallet_SendToAddress_Call) Run(run func(args onchain.WalletSendArgs)) *MockWallet_SendToAddress_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 onchain.WalletSendArgs
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 uint64
-		if args[1] != nil {
-			arg1 = args[1].(uint64)
-		}
-		var arg2 float64
-		if args[2] != nil {
-			arg2 = args[2].(float64)
-		}
-		var arg3 bool
-		if args[3] != nil {
-			arg3 = args[3].(bool)
+			arg0 = args[0].(onchain.WalletSendArgs)
 		}
 		run(
 			arg0,
-			arg1,
-			arg2,
-			arg3,
 		)
 	})
 	return _c
@@ -483,7 +531,7 @@ func (_c *MockWallet_SendToAddress_Call) Return(s string, err error) *MockWallet
 	return _c
 }
 
-func (_c *MockWallet_SendToAddress_Call) RunAndReturn(run func(address string, amount uint64, satPerVbyte float64, sendAll bool) (string, error)) *MockWallet_SendToAddress_Call {
+func (_c *MockWallet_SendToAddress_Call) RunAndReturn(run func(args onchain.WalletSendArgs) (string, error)) *MockWallet_SendToAddress_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/onchain/onchain.go
+++ b/internal/onchain/onchain.go
@@ -86,15 +86,23 @@ type AddressProvider interface {
 	IsUsed(address string) (bool, error)
 }
 
+type WalletSendArgs struct {
+	Address     string
+	Amount      uint64
+	SatPerVbyte float64
+	SendAll     bool
+}
+
 type Wallet interface {
 	NewAddress() (string, error)
-	SendToAddress(address string, amount uint64, satPerVbyte float64, sendAll bool) (string, error)
+	SendToAddress(args WalletSendArgs) (string, error)
 	Ready() bool
 	GetBalance() (*Balance, error)
 	GetWalletInfo() WalletInfo
 	Disconnect() error
 	GetTransactions(limit, offset uint64) ([]*WalletTransaction, error)
 	BumpTransactionFee(txId string, satPerVbyte float64) (string, error)
+	GetSendFee(args WalletSendArgs) (send uint64, fee uint64, err error)
 }
 
 type ElectrumOptions struct {

--- a/internal/onchain/wallet/wallet_test.go
+++ b/internal/onchain/wallet/wallet_test.go
@@ -49,7 +49,11 @@ func TestWallet_BumpTransactionFee(t *testing.T) {
 	someAddress := test.GetNewAddress(test.BtcCli)
 	amount := int64(1000)
 
-	txId, err := wallet.SendToAddress(someAddress, uint64(amount), 1, false)
+	txId, err := wallet.SendToAddress(onchain.WalletSendArgs{
+		Address:     someAddress,
+		Amount:      uint64(amount),
+		SatPerVbyte: 1,
+	})
 	require.NoError(t, err)
 	tx := getTransaction(txId)
 
@@ -79,7 +83,11 @@ func TestSend(t *testing.T) {
 			addr := cli("getnewaddress")
 
 			t.Run("Normal", func(t *testing.T) {
-				txid, err := wallet.SendToAddress(addr, 10000, 1, false)
+				txid, err := wallet.SendToAddress(onchain.WalletSendArgs{
+					Address:     addr,
+					Amount:      10000,
+					SatPerVbyte: 1,
+				})
 				require.NoError(t, err)
 				rawTx := cli("getrawtransaction " + txid)
 				tx, err := boltz.NewTxFromHex(currency, rawTx, nil)
@@ -99,7 +107,11 @@ func TestSend(t *testing.T) {
 			minFeeRate := 1.0
 
 			t.Run("SendFee", func(t *testing.T) {
-				amount, fee, err := wallet.GetSendFee(addr, 0, minFeeRate, true)
+				amount, fee, err := wallet.GetSendFee(onchain.WalletSendArgs{
+					Address:     addr,
+					SatPerVbyte: minFeeRate,
+					SendAll:     true,
+				})
 				require.NoError(t, err)
 
 				balance, err := wallet.GetBalance()

--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -1975,6 +1975,9 @@ func TestWalletSendReceive(t *testing.T) {
 		satPerVbyte := 10.0
 		sendAll := true
 
+		defaultEstimate, err := chain.EstimateFee(boltz.CurrencyBtc)
+		require.NoError(t, err)
+
 		tests := []struct {
 			desc    string
 			request *boltzrpc.WalletSendRequest
@@ -1991,7 +1994,11 @@ func TestWalletSendReceive(t *testing.T) {
 				result: "txid",
 				err:    require.NoError,
 				setup: func(mockWallet *onchainmock.MockWallet) {
-					mockWallet.EXPECT().SendToAddress("address", uint64(1000), mock.Anything, mock.Anything).Return("txid", nil)
+					mockWallet.EXPECT().SendToAddress(onchain.WalletSendArgs{
+						Address:     "address",
+						Amount:      1000,
+						SatPerVbyte: defaultEstimate,
+					}).Return("txid", nil)
 				},
 			},
 			{
@@ -2004,7 +2011,12 @@ func TestWalletSendReceive(t *testing.T) {
 				result: "txid",
 				err:    require.NoError,
 				setup: func(mockWallet *onchainmock.MockWallet) {
-					mockWallet.EXPECT().SendToAddress("address", uint64(1000), satPerVbyte, mock.Anything).Return("txid", nil)
+					mockWallet.EXPECT().SendToAddress(onchain.WalletSendArgs{
+						Address:     "address",
+						Amount:      1000,
+						SatPerVbyte: satPerVbyte,
+						SendAll:     false,
+					}).Return("txid", nil)
 				},
 			},
 			{
@@ -2017,7 +2029,12 @@ func TestWalletSendReceive(t *testing.T) {
 				result: "txid",
 				err:    require.NoError,
 				setup: func(mockWallet *onchainmock.MockWallet) {
-					mockWallet.EXPECT().SendToAddress("address", uint64(1000), mock.Anything, sendAll).Return("txid", nil)
+					mockWallet.EXPECT().SendToAddress(onchain.WalletSendArgs{
+						Address:     "address",
+						Amount:      1000,
+						SatPerVbyte: defaultEstimate,
+						SendAll:     sendAll,
+					}).Return("txid", nil)
 				},
 			},
 			{
@@ -2041,7 +2058,11 @@ func TestWalletSendReceive(t *testing.T) {
 					Amount:  1000,
 				},
 				setup: func(mockWallet *onchainmock.MockWallet) {
-					mockWallet.EXPECT().SendToAddress("address", uint64(1000), mock.Anything, mock.Anything).Return("", errors.New("wallet error"))
+					mockWallet.EXPECT().SendToAddress(onchain.WalletSendArgs{
+						Address:     "address",
+						Amount:      1000,
+						SatPerVbyte: defaultEstimate,
+					}).Return("", errors.New("wallet error"))
 				},
 				err: require.Error,
 			},


### PR DESCRIPTION
introduce `WalletSendArgs` struct and add `GetSendFee` to the interface
(in preparation for lwk)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for estimating wallet send fees through a new method.

- **Refactor**
  - Unified wallet send operations to use a single argument structure for address, amount, fee rate, and send-all flag.
  - Updated all related interfaces, implementations, and tests to use the new argument structure for wallet send and fee estimation operations.

- **Tests**
  - Updated test cases and mocks to use the new unified argument structure for wallet send and fee estimation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->