### PR TITLE
docs: bring readme resource section in line with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The official documentation is available [here](https://docs.boltz.exchange/v/bol
 
 ## Resources
 
-* Get Help: [Support](https://support.boltz.exchange/hc/center) | [Discord](https://discord.gg/QBvZGcW) | [Telegram](https://t.me/boltzhq)
-* Read our Docs: [Docs Home](https://docs.boltz.exchange/)
+* Get Help: [Support Center](https://support.boltz.exchange/hc/center/) | [Discord](https://discord.gg/QBvZGcW) | [Telegram](https://t.me/boltzhq)
+* Read the Docs: [Docs Home](https://docs.boltz.exchange/)
 * Read our Blog: [Substack](https://blog.boltz.exchange/)
 * Follow us: [X/Twitter](https://twitter.com/Boltzhq) | [Nostr](https://snort.social/p/npub1psm37hke2pmxzdzraqe3cjmqs28dv77da74pdx8mtn5a0vegtlas9q8970)
-* Open a Lightning channel with us: [CLN](https://amboss.space/node/02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018) | [LND](https://amboss.space/node/026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2)
+* Open a Lightning channel with us: [CLN](https://amboss.space/node/02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018) | [LND](https://amboss.space/node/026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2)&#x20;

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ The official documentation is available [here](https://docs.boltz.exchange/v/bol
 * Read the Docs: [Docs Home](https://docs.boltz.exchange/)
 * Read our Blog: [Substack](https://blog.boltz.exchange/)
 * Follow us: [X/Twitter](https://twitter.com/Boltzhq) | [Nostr](https://snort.social/p/npub1psm37hke2pmxzdzraqe3cjmqs28dv77da74pdx8mtn5a0vegtlas9q8970)
-* Open a Lightning channel with us: [CLN](https://amboss.space/node/02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018) | [LND](https://amboss.space/node/026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2)&#x20;
+* Open a Lightning channel with us: [CLN](https://amboss.space/node/02d96eadea3d780104449aca5c93461ce67c1564e2e1d73225fa67dd3b997a6018) | [LND](https://amboss.space/node/026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2)


### PR DESCRIPTION
Just for the sake of having the exact same everywhere
- https://github.com/BoltzExchange/boltz-web-app/blob/main/README.md#resources
- https://github.com/BoltzExchange/boltz-backend/blob/master/README.md#resources
- https://github.com/BoltzExchange/docs/blob/main/README.md#resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated resource link descriptions in the README for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->