### PR TITLE
feat: password authentication

### DIFF
--- a/cmd/boltzcli/boltzcli.go
+++ b/cmd/boltzcli/boltzcli.go
@@ -91,6 +91,11 @@ func main() {
 			Usage:   "Id or name of the tenant to use for the request",
 			EnvVars: []string{"BOLTZ_TENANT"},
 		},
+		&cli.StringFlag{
+			Name:    "password",
+			Usage:   "Password for authentication",
+			EnvVars: []string{"BOLTZ_PASSWORD"},
+		},
 	}
 	app.Commands = []*cli.Command{
 		getInfoCommand,
@@ -140,6 +145,7 @@ func getConnection(ctx *cli.Context) client.Connection {
 
 	tlsCert := ctx.String("tlscert")
 	macaroon := ctx.String("macaroon")
+	password := ctx.String("password")
 
 	if tlsCert == "" {
 		defaultPath := path.Join(dataDir, "tls.cert")
@@ -159,6 +165,7 @@ func getConnection(ctx *cli.Context) client.Connection {
 
 		NoMacaroons:  ctx.Bool("no-macaroons"),
 		MacaroonPath: macaroon,
+		Password:     password,
 	}
 
 	err := boltz.Connect()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,4 +96,7 @@ adminMacaroonPath = ""
 
 # Path to the read-only macaroon for the gRPC and REST interface
 readOnlyMacaroonPath = ""
+
+# Password for authentication (alternative to macaroons and takes precedence if set)
+password = ""
 ````

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,7 @@ type RpcOptions struct {
 	NoMacaroons          bool   `long:"rpc.no-macaroons" description:"Disables Macaroon authentication"`
 	AdminMacaroonPath    string `long:"rpc.adminmacaroonpath" description:"Path to the admin Macaroon"`
 	ReadonlyMacaroonPath string `long:"rpc.readonlymacaroonpath" description:"Path to the readonly macaroon"`
-	Password             string `long:"rpc.password" description:"Password for authentication (alternative to macaroons and takes precedence if set)"`
+	Password             string `long:"rpc.password" description:"Password for authentication (alternative to macaroons and takes precedence if set)" json:"-"`
 }
 
 type Config struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type RpcOptions struct {
 	NoMacaroons          bool   `long:"rpc.no-macaroons" description:"Disables Macaroon authentication"`
 	AdminMacaroonPath    string `long:"rpc.adminmacaroonpath" description:"Path to the admin Macaroon"`
 	ReadonlyMacaroonPath string `long:"rpc.readonlymacaroonpath" description:"Path to the readonly macaroon"`
+	Password             string `long:"rpc.password" description:"Password for authentication (alternative to macaroons and takes precedence if set)"`
 }
 
 type Config struct {

--- a/internal/rpcserver/password.go
+++ b/internal/rpcserver/password.go
@@ -1,0 +1,65 @@
+package rpcserver
+
+import (
+	"context"
+	"crypto/subtle"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type PasswordAuth struct {
+	password []byte
+}
+
+func NewPasswordAuth(password string) *PasswordAuth {
+	return &PasswordAuth{[]byte(password)}
+}
+
+func (auth *PasswordAuth) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		if err := auth.validateRequest(ctx); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+func (auth *PasswordAuth) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		if err := auth.validateRequest(ss.Context()); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+func (auth *PasswordAuth) validateRequest(ctx context.Context) error {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "metadata is not provided")
+	}
+
+	password := md.Get("password")
+	if len(password) != 1 {
+		return status.Error(codes.Unauthenticated, "password is not provided")
+	}
+
+	if subtle.ConstantTimeCompare(auth.password, []byte(password[0])) == 0 {
+		return status.Error(codes.Unauthenticated, "invalid password")
+	}
+
+	return nil
+}

--- a/pkg/boltzrpc/client/connection.go
+++ b/pkg/boltzrpc/client/connection.go
@@ -23,12 +23,18 @@ type Connection struct {
 
 	NoMacaroons  bool
 	MacaroonPath string
+	Password     string
 
 	Ctx context.Context
 }
 
 func (connection *Connection) SetMacaroon(macaroon string) {
 	md := metadata.Pairs("macaroon", macaroon)
+	connection.Ctx = metadata.NewOutgoingContext(context.Background(), md)
+}
+
+func (connection *Connection) SetPassword(password string) {
+	md := metadata.Pairs("password", password)
 	connection.Ctx = metadata.NewOutgoingContext(context.Background(), md)
 }
 
@@ -60,7 +66,9 @@ func (connection *Connection) Connect() error {
 	if connection.Ctx == nil {
 		connection.Ctx = context.Background()
 
-		if !connection.NoMacaroons {
+		if connection.Password != "" {
+			connection.SetPassword(connection.Password)
+		} else if !connection.NoMacaroons {
 			macaroonFile, err := os.ReadFile(connection.MacaroonPath)
 
 			if err != nil {


### PR DESCRIPTION
Simple password authentication which can be used instead of macaroons.
When set, no macaroons will be generated by the server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced password-based authentication as an alternative to macaroon authentication for CLI and RPC server.
  - Added support for specifying a password via CLI flag, environment variable, or configuration file.
  - Enhanced documentation to include the new password authentication option.

- **Bug Fixes**
  - Improved authentication error handling and messaging for missing or incorrect credentials.

- **Tests**
  - Added tests to verify password authentication, including correct and incorrect password scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->