### PR TITLE
refactor: rename password header to authorization

### DIFF
--- a/internal/rpcserver/password.go
+++ b/internal/rpcserver/password.go
@@ -52,12 +52,12 @@ func (auth *PasswordAuth) validateRequest(ctx context.Context) error {
 		return status.Error(codes.Unauthenticated, "metadata is not provided")
 	}
 
-	password := md.Get("authorization")
-	if len(password) != 1 {
+	authorization := md.Get("authorization")
+	if len(authorization) != 1 {
 		return status.Error(codes.Unauthenticated, "invalid authorization")
 	}
 
-	if subtle.ConstantTimeCompare(auth.password, []byte(password[0])) == 0 {
+	if subtle.ConstantTimeCompare(auth.password, []byte(authorization[0])) == 0 {
 		return status.Error(codes.Unauthenticated, "invalid authorization")
 	}
 

--- a/internal/rpcserver/password.go
+++ b/internal/rpcserver/password.go
@@ -52,13 +52,13 @@ func (auth *PasswordAuth) validateRequest(ctx context.Context) error {
 		return status.Error(codes.Unauthenticated, "metadata is not provided")
 	}
 
-	password := md.Get("password")
+	password := md.Get("authorization")
 	if len(password) != 1 {
-		return status.Error(codes.Unauthenticated, "password is not provided")
+		return status.Error(codes.Unauthenticated, "invalid authorization")
 	}
 
 	if subtle.ConstantTimeCompare(auth.password, []byte(password[0])) == 0 {
-		return status.Error(codes.Unauthenticated, "invalid password")
+		return status.Error(codes.Unauthenticated, "invalid authorization")
 	}
 
 	return nil

--- a/internal/rpcserver/password.go
+++ b/internal/rpcserver/password.go
@@ -10,6 +10,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var ErrInvalidAuthorization = status.Error(codes.Unauthenticated, "invalid authorization")
+
 type PasswordAuth struct {
 	password []byte
 }
@@ -54,11 +56,11 @@ func (auth *PasswordAuth) validateRequest(ctx context.Context) error {
 
 	authorization := md.Get("authorization")
 	if len(authorization) != 1 {
-		return status.Error(codes.Unauthenticated, "invalid authorization")
+		return ErrInvalidAuthorization
 	}
 
 	if subtle.ConstantTimeCompare(auth.password, []byte(authorization[0])) == 0 {
-		return status.Error(codes.Unauthenticated, "invalid authorization")
+		return ErrInvalidAuthorization
 	}
 
 	return nil

--- a/pkg/boltzrpc/client/connection.go
+++ b/pkg/boltzrpc/client/connection.go
@@ -34,7 +34,7 @@ func (connection *Connection) SetMacaroon(macaroon string) {
 }
 
 func (connection *Connection) SetPassword(password string) {
-	md := metadata.Pairs("password", password)
+	md := metadata.Pairs("authorization", password)
 	connection.Ctx = metadata.NewOutgoingContext(context.Background(), md)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated authentication to use "authorization" instead of "password" for gRPC metadata and error messages. This change unifies terminology and improves consistency across authentication processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->