### PR TITLE
fix: reverse swap bip21 error handling

### DIFF
--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -633,8 +633,7 @@ func (server *routedBoltzServer) checkMagicRoutingHint(decoded *lightning.Decode
 	if pubKey := decoded.MagicRoutingHint; pubKey != nil {
 		logger.Info("Found magic routing hint in invoice")
 		reverseBip21, err := server.boltz.GetReverseSwapBip21(invoice)
-		var boltzErr boltz.Error
-		if err != nil && !errors.As(err, &boltzErr) {
+		if err != nil {
 			return nil, fmt.Errorf("could not get reverse swap bip21: %w", err)
 		}
 


### PR DESCRIPTION
there is no reason to treat an error originating from boltz differently here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to ensure all errors during certain operations are now properly reported to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->