### PR TITLE
fix: correct name for `LightningOptions` in config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,6 @@ import (
 	"github.com/BoltzExchange/boltz-client/v2/internal/build"
 	"github.com/BoltzExchange/boltz-client/v2/internal/cln"
 	"github.com/BoltzExchange/boltz-client/v2/internal/database"
-	"github.com/BoltzExchange/boltz-client/v2/internal/lightning"
 	"github.com/BoltzExchange/boltz-client/v2/internal/lnd"
 	"github.com/BoltzExchange/boltz-client/v2/internal/utils"
 )
@@ -75,11 +74,9 @@ type Config struct {
 
 	Standalone bool `long:"standalone" description:"Run boltz-client without a lightning node"`
 
-	Lightning lightning.LightningNode `json:"-"`
-
-	LightningOptions *LightningOptions  `group:"Lightning options"`
-	RPC              *RpcOptions        `group:"RPC options"`
-	Database         *database.Database `group:"Database options"`
+	Lightning *LightningOptions  `group:"Lightning options"`
+	RPC       *RpcOptions        `group:"RPC options"`
+	Database  *database.Database `group:"Database options"`
 
 	MempoolApi       string `long:"mempool" description:"mempool.space API to use for fee estimations; set to empty string to disable"`
 	MempoolLiquidApi string `long:"mempool-liquid" description:"mempool.space liquid API to use for fee estimations; set to empty string to disable"`
@@ -138,7 +135,7 @@ func LoadConfig(dataDir string) (*Config, error) {
 			ServerName: "cln",
 		},
 
-		LightningOptions: &LightningOptions{
+		Lightning: &LightningOptions{
 			RoutingFeeLimitPpm: 2500,
 		},
 

--- a/internal/rpcserver/server.go
+++ b/internal/rpcserver/server.go
@@ -197,7 +197,7 @@ func (server *routedBoltzServer) start(cfg *config.Config) (err error) {
 
 	server.nursery = nursery.New(
 		cfg.MaxZeroConfAmount,
-		cfg.LightningOptions.RoutingFeeLimitPpm,
+		cfg.Lightning.RoutingFeeLimitPpm,
 		server.network,
 		server.lightning,
 		server.onchain,


### PR DESCRIPTION
old `Lightning` value (not used anymore) in config wasnt used and caused the config to be ignored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated configuration fields related to Lightning settings for improved clarity and consistency. No changes to app behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->