### PR TITLE
chore: fix flaky autoswap unit test

### DIFF
--- a/internal/autoswap/chain_test.go
+++ b/internal/autoswap/chain_test.go
@@ -272,8 +272,10 @@ func TestChainSwapper(t *testing.T) {
 		cleaned := false
 		blockUpdates := make(chan *onchain.BlockEpoch)
 		rpcMock.EXPECT().GetBlockUpdates(fromWallet.GetWalletInfo().Currency).Return(blockUpdates, func() {
-			cleaned = true
-			close(blockUpdates)
+			if !cleaned {
+				cleaned = true
+				close(blockUpdates)
+			}
 		})
 
 		err := swapper.UpdateChainConfig(&autoswaprpc.UpdateChainConfigRequest{


### PR DESCRIPTION
make sure the channel isnt closed twice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of test cleanup to prevent issues during repeated cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->