### PR TITLE
fix: reverse swap double broadcast

### DIFF
--- a/internal/nursery/reverse.go
+++ b/internal/nursery/reverse.go
@@ -160,6 +160,11 @@ func (nursery *Nursery) handleReverseSwapStatus(reverseSwap *database.ReverseSwa
 		fallthrough
 
 	case boltz.TransactionConfirmed:
+		// already broadcasted on transaction.mempool
+		if reverseSwap.ClaimTransactionId != "" {
+			break
+		}
+
 		err := nursery.database.SetReverseSwapLockupTransactionId(reverseSwap, event.Transaction.Id)
 
 		if err != nil {


### PR DESCRIPTION
if a swap accepts zero-conf and goes into transaction.confirmed before
the invoice is being settled, the client tries to broadcast again,
leading to an insufficient replacement error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reverse swap status updates to prevent redundant processing when a claim transaction has already been broadcast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->