### PR TITLE
fix: check if reverse swap routing fee is nil

### DIFF
--- a/cmd/boltzcli/commands.go
+++ b/cmd/boltzcli/commands.go
@@ -387,7 +387,7 @@ func swapInfoStream(ctx *cli.Context, id string, json bool) error {
 					fmt.Printf("Lockup transaction ID: %s\n", swap.LockupTransactionId)
 				case boltz.InvoiceSettled:
 					fmt.Printf("Claim transaction ID: %s\n", swap.ClaimTransactionId)
-					if swap.ExternalPay {
+					if swap.ExternalPay || swap.RoutingFeeMsat == nil {
 						fmt.Printf("Paid %d sat onchain fee and %d sat boltz fee\n", *swap.OnchainFee, *swap.ServiceFee)
 					} else {
 						fmt.Printf("Paid %d msat routing fee, %d sat onchain fee and %d sat boltz fee\n", *swap.RoutingFeeMsat, *swap.OnchainFee, *swap.ServiceFee)
@@ -1415,6 +1415,7 @@ func claimSwaps(ctx *cli.Context) error {
 	fmt.Println("Claim transaction ID: " + response.TransactionId)
 	return nil
 }
+
 var routingFeeLimitFlag = &cli.Uint64Flag{
 	Name:  "routing-fee-limit-ppm",
 	Usage: "The routing fee limit for paying the lightning invoice in ppm (parts per million)",

--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -1380,15 +1380,19 @@ func TestAutoSwap(t *testing.T) {
 				info := stream(boltzrpc.SwapState_PENDING)
 				require.NotNil(t, info.ReverseSwap)
 				require.True(t, info.ReverseSwap.IsAuto)
+
+				stream(boltzrpc.SwapState_SUCCESSFUL)
+				test.MineBlock()
 			})
 
 			t.Run("Auto", func(t *testing.T) {
 				setupRecommendation(t)
 
+				stream, _ := swapStream(t, admin, "")
+
 				_, err := autoSwap.Enable()
 				require.NoError(t, err)
 
-				stream, _ := swapStream(t, admin, "")
 				test.MineBlock()
 				info := stream(boltzrpc.SwapState_PENDING)
 				require.NotNil(t, info.ReverseSwap)


### PR DESCRIPTION
can happen if the daemon fails to get the routing fee from the LN node


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of fee details for reverse swaps in the Invoice Settled status, ensuring accurate fee information is shown based on swap conditions.
  * Enhanced test coverage for swap success states and improved the reliability of auto swap behavior in test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->