### PR TITLE
fix: subscribe to previous swapIds after connecting

### DIFF
--- a/pkg/boltz/ws.go
+++ b/pkg/boltz/ws.go
@@ -151,8 +151,13 @@ func (boltz *Websocket) Connect() error {
 		}
 	}()
 
-	if len(boltz.swapIds) > 0 {
-		if err := boltz.subscribe(boltz.swapIds); err != nil {
+	boltz.swapIdsLock.Lock()
+	swapIds := make([]string, len(boltz.swapIds))
+	copy(swapIds, boltz.swapIds)
+	boltz.swapIdsLock.Unlock()
+
+	if len(swapIds) > 0 {
+		if err := boltz.subscribe(swapIds); err != nil {
 			return fmt.Errorf("failed to subscribe to existing swaps: %w", err)
 		}
 	}

--- a/pkg/boltz/ws.go
+++ b/pkg/boltz/ws.go
@@ -150,6 +150,13 @@ func (boltz *Websocket) Connect() error {
 			}
 		}
 	}()
+
+	if len(boltz.swapIds) > 0 {
+		if err := boltz.subscribe(boltz.swapIds); err != nil {
+			return fmt.Errorf("failed to subscribe to existing swaps: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically re-subscribes to previously tracked swaps when reconnecting to the WebSocket.

* **Bug Fixes**
  * Improved reliability by ensuring existing swaps are re-subscribed after a connection is re-established.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->