### PR TITLE
fix: set `swap` to nil when recommended amount is smaller than reserve

### DIFF
--- a/internal/autoswap/strategy.go
+++ b/internal/autoswap/strategy.go
@@ -49,10 +49,10 @@ func (cfg *LightningConfig) channelRecommendation(channel *lightning.LightningCh
 			reserve := boltz.CalculatePercentage(cfg.reserve, channel.Capacity)
 			if swap.Amount < reserve {
 				logger.Warnf(
-					"Recommended amount %d of channel %d is smaller than the reserve %d",
+					"Recommended amount %d of channel %d is lower than the reserve %d, not recommending swap",
 					swap.Amount, channel.Id, reserve,
 				)
-				swap.Amount = 0
+				swap = nil
 			} else {
 				swap.Amount -= reserve
 			}


### PR DESCRIPTION
the recommendation is still validated if we just set amount to 0, causing misleading log errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of swap recommendations when the amount is below the reserve threshold, ensuring swaps are not suggested in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->