### PR TITLE
feat: implement `transaction.direct` status update

### DIFF
--- a/internal/database/reverse.go
+++ b/internal/database/reverse.go
@@ -266,6 +266,17 @@ func (database *Database) QueryReverseSwapByClaimTransaction(txId string) (rever
 	return reverseSwap, err
 }
 
+func (database *Database) QueryReverseSwapByClaimAddress(claimAddress string) (*ReverseSwap, error) {
+	swaps, err := database.queryReverseSwaps("SELECT * FROM reverseSwaps WHERE claimAddress = ? AND state = ?", claimAddress, boltzrpc.SwapState_PENDING)
+	if err != nil {
+		return nil, err
+	}
+	if len(swaps) > 0 {
+		return swaps[0], nil
+	}
+	return nil, sql.ErrNoRows
+}
+
 const claimableSwapsQuery = `
 SELECT * FROM reverseSwaps
 WHERE fromCurrency = ?

--- a/internal/database/reverse.go
+++ b/internal/database/reverse.go
@@ -266,17 +266,6 @@ func (database *Database) QueryReverseSwapByClaimTransaction(txId string) (rever
 	return reverseSwap, err
 }
 
-func (database *Database) QueryReverseSwapByClaimAddress(claimAddress string) (*ReverseSwap, error) {
-	swaps, err := database.queryReverseSwaps("SELECT * FROM reverseSwaps WHERE claimAddress = ? AND state = ?", claimAddress, boltzrpc.SwapState_PENDING)
-	if err != nil {
-		return nil, err
-	}
-	if len(swaps) > 0 {
-		return swaps[0], nil
-	}
-	return nil, sql.ErrNoRows
-}
-
 const claimableSwapsQuery = `
 SELECT * FROM reverseSwaps
 WHERE fromCurrency = ?

--- a/internal/nursery/nursery.go
+++ b/internal/nursery/nursery.go
@@ -249,7 +249,7 @@ func (nursery *Nursery) startSwapListener() {
 		for {
 			select {
 			case notification := <-notifier:
-				if err := nursery.checkExternalReverseSwaps(notification.Currency, notification.TxId); err != nil {
+				if err := nursery.checkExternalReverseSwaps(notification.Currency); err != nil {
 					logger.Errorf("Could not check external reverse swaps: %v", err)
 				}
 			case <-nursery.ctx.Done():

--- a/internal/nursery/nursery.go
+++ b/internal/nursery/nursery.go
@@ -365,13 +365,22 @@ func (nursery *Nursery) populateOutputs(outputs []*Output) (valid []*Output, det
 	return
 }
 
-func (nursery *Nursery) CheckAmounts(swapType boltz.SwapType, pair boltz.Pair, sendAmount uint64, receiveAmount uint64, serviceFee boltz.Percentage) (err error) {
+func (nursery *Nursery) GetFeeEstimations() (boltz.FeeEstimations, error) {
 	fees := make(boltz.FeeEstimations)
+	var err error
 	fees[boltz.CurrencyLiquid], err = nursery.onchain.EstimateFee(boltz.CurrencyLiquid)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	fees[boltz.CurrencyBtc], err = nursery.onchain.EstimateFee(boltz.CurrencyBtc)
+	if err != nil {
+		return nil, err
+	}
+	return fees, nil
+}
+
+func (nursery *Nursery) CheckAmounts(swapType boltz.SwapType, pair boltz.Pair, sendAmount uint64, receiveAmount uint64, serviceFee boltz.Percentage) (err error) {
+	fees, err := nursery.GetFeeEstimations()
 	if err != nil {
 		return err
 	}

--- a/internal/nursery/nursery_test.go
+++ b/internal/nursery/nursery_test.go
@@ -145,6 +145,7 @@ func TestChooseDirectOutput(t *testing.T) {
 					To:   boltz.CurrencyLiquid,
 				},
 				ServiceFeePercent: 1,
+				OnchainAmount:     9500,
 				InvoiceAmount:     10000,
 			},
 			feeEstimations: boltz.FeeEstimations{
@@ -171,6 +172,7 @@ func TestChooseDirectOutput(t *testing.T) {
 					To:   boltz.CurrencyBtc,
 				},
 				InvoiceAmount:     10000,
+				OnchainAmount:     9500,
 				ServiceFeePercent: 1,
 			},
 			feeEstimations: boltz.FeeEstimations{
@@ -181,12 +183,16 @@ func TestChooseDirectOutput(t *testing.T) {
 			err:      require.NoError,
 		},
 		{
-			name: "Liquid/UnknownValue",
+			name: "Overpaid",
 			outputs: []*onchain.Output{
 				{
 					TxId:  "tx1",
-					Value: 0,
+					Value: 10500,
 				},
+			},
+			expected: &onchain.Output{
+				TxId:  "tx1",
+				Value: 10500,
 			},
 			swap: &database.ReverseSwap{
 				Pair: boltz.Pair{
@@ -194,15 +200,12 @@ func TestChooseDirectOutput(t *testing.T) {
 					To:   boltz.CurrencyLiquid,
 				},
 				InvoiceAmount:     10000,
+				OnchainAmount:     9500,
 				ServiceFeePercent: 1,
 			},
 			feeEstimations: boltz.FeeEstimations{
 				boltz.CurrencyLiquid: 0.1,
 				boltz.CurrencyBtc:    1,
-			},
-			expected: &onchain.Output{
-				TxId:  "tx1",
-				Value: 0,
 			},
 			err: require.NoError,
 		},

--- a/internal/nursery/refund.go
+++ b/internal/nursery/refund.go
@@ -2,6 +2,7 @@ package nursery
 
 import (
 	"fmt"
+
 	"github.com/BoltzExchange/boltz-client/v2/internal/database"
 	"github.com/BoltzExchange/boltz-client/v2/internal/logger"
 	"github.com/BoltzExchange/boltz-client/v2/internal/onchain"
@@ -31,7 +32,7 @@ func (nursery *Nursery) startBlockListener(currency boltz.Currency) *utils.Chann
 				}
 			}
 
-			if err := nursery.checkExternalReverseSwaps(currency, ""); err != nil {
+			if err := nursery.checkExternalReverseSwaps(currency); err != nil {
 				logger.Error("Could not check external reverse swaps: " + err.Error())
 			}
 		}

--- a/internal/nursery/reverse.go
+++ b/internal/nursery/reverse.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/BoltzExchange/boltz-client/v2/internal/lightning"
 	"github.com/BoltzExchange/boltz-client/v2/internal/onchain"
+	liquid_wallet "github.com/BoltzExchange/boltz-client/v2/internal/onchain/liquid-wallet"
 	"github.com/btcsuite/btcd/btcec/v2"
 
 	"github.com/BoltzExchange/boltz-client/v2/internal/database"
@@ -150,6 +152,51 @@ func (nursery *Nursery) handleReverseSwapStatus(reverseSwap *database.ReverseSwa
 	}
 
 	switch parsedStatus {
+	case boltz.TransactionDirect:
+		var blindingKey *btcec.PrivateKey
+		if reverseSwap.Pair.To == boltz.CurrencyLiquid && reverseSwap.WalletId != nil {
+			wallet, err := nursery.onchain.GetAnyWallet(onchain.WalletChecker{Id: reverseSwap.WalletId, AllowReadonly: true})
+			if err != nil {
+				handleError("Could not get wallet: " + err.Error())
+				return
+			}
+			if liquid_wallet, ok := wallet.(*liquid_wallet.Wallet); ok {
+				blindingKey, err = liquid_wallet.DeriveBlindingKey(reverseSwap.ClaimAddress)
+				if err != nil {
+					handleError("Could not derive blinding key: " + err.Error())
+					return
+				}
+			} else {
+				// gdk handles direct transactions via its own transaction notifier
+				break
+			}
+		}
+		directTransaction, err := boltz.NewTxFromHex(reverseSwap.Pair.To, event.Transaction.Hex, blindingKey)
+		if err != nil {
+			handleError("Could not parse direct transaction: " + err.Error())
+			return
+		}
+		_, value, err := directTransaction.FindVout(nursery.network, reverseSwap.ClaimAddress)
+		if err != nil {
+			handleError("Could not find vout: " + err.Error())
+			return
+		}
+		_, err = nursery.onchain.BroadcastTransaction(directTransaction)
+		if err != nil {
+			msg := strings.ToLower(err.Error())
+			errors := []string{"transaction already in block chain", "transaction outputs already in utxo set"}
+			if !slices.Contains(errors, msg) {
+				handleError("Could not broadcast transaction: " + err.Error())
+				return
+			}
+		}
+		nursery.handleReverseSwapDirectPayments(reverseSwap, []*onchain.Output{
+			{
+				TxId:  event.Transaction.Id,
+				Value: value,
+			},
+		})
+		return
 	case boltz.TransactionMempool:
 		if err := nursery.database.SetReverseSwapPaidAt(reverseSwap, time.Now()); err != nil {
 			handleError("Could not set paid at in database: " + err.Error())
@@ -235,36 +282,64 @@ func (nursery *Nursery) handleReverseSwapStatus(reverseSwap *database.ReverseSwa
 	nursery.sendReverseSwapUpdate(*reverseSwap)
 }
 
-func (nursery *Nursery) handleReverseSwapDirectPayment(swap *database.ReverseSwap, output *onchain.Output) {
-	err := nursery.database.RunTx(func(tx *database.Transaction) error {
-		logger.Debugf("Found direct payment to Reverse Swap %s", swap.Id)
-		if swap.ClaimTransactionId != "" && swap.ClaimTransactionId != output.TxId {
-			return fmt.Errorf("claim transaction changed: %s", swap.ClaimTransactionId)
+func (nursery *Nursery) chooseDirectOutput(swap *database.ReverseSwap, feeEstimations boltz.FeeEstimations, outputs []*onchain.Output) (*onchain.Output, error) {
+	slices.SortFunc(outputs, func(a, b *onchain.Output) int {
+		return cmp.Compare(a.Value, b.Value)
+	})
+
+	for _, output := range outputs {
+		found, err := nursery.database.QueryReverseSwapByClaimTransaction(output.TxId)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("could not query reverse swap by claim transaction: %s", err)
+		}
+		if found != nil && found.Id != swap.Id {
+			logger.Infof("Direct Transaction is claim of %s", found.Id)
+			continue
 		}
 
-		currency := swap.Pair.To
-		pairs, err := nursery.boltz.GetReversePairs()
-		if err != nil {
-			return fmt.Errorf("get reverse pairs: %s", err)
-		}
-		pair, err := boltz.FindPair(swap.Pair, pairs)
-		if err != nil {
-			return fmt.Errorf("find reverse swap pair: %s", err)
-		}
-		claimFee := pair.Fees.MinerFees.Claim
-		if currency == boltz.CurrencyLiquid && claimFee > 100 && nursery.network == boltz.MainNet {
-			return fmt.Errorf("claim fee too high for liquid: %d", claimFee)
-		}
 		// we dont know the output value of liquid when the claim address is external
-		expectedAmount := swap.OnchainAmount - claimFee - 50
-		if (currency == boltz.CurrencyBtc || output.Value != 0) && output.Value < expectedAmount {
-			return fmt.Errorf("locked up less onchain coins than expected: %d < %d", output.Value, expectedAmount)
+		if swap.Pair.To == boltz.CurrencyLiquid && swap.WalletId == nil && output.Value == 0 {
+			logger.Infof("Skipping amount validation for liquid since we cant unblind external outputs")
+		} else {
+			if output.Value < swap.InvoiceAmount {
+				if err := boltz.CheckAmounts(
+					boltz.ReverseSwap,
+					swap.Pair,
+					swap.InvoiceAmount,
+					output.Value,
+					swap.ServiceFeePercent,
+					feeEstimations,
+					true,
+				); err != nil {
+					logger.Infof("Output from %s does not pass amount checks: %s", output.TxId, err)
+					continue
+				}
+			}
 		}
-		if err := tx.SetReverseSwapClaimTransactionId(swap, output.TxId, 0); err != nil {
-			return fmt.Errorf("set paid at: %s", err)
+
+		return output, nil
+	}
+	return nil, nil
+}
+
+func (nursery *Nursery) handleReverseSwapDirectPayments(swap *database.ReverseSwap, outputs []*onchain.Output) {
+	err := nursery.database.RunTx(func(tx *database.Transaction) error {
+		logger.Debugf("Found %d direct payments to Reverse Swap %s", len(outputs), swap.Id)
+		feeEstimations, err := nursery.GetFeeEstimations()
+		if err != nil {
+			return fmt.Errorf("get fee estimations: %s", err)
 		}
-		if currency == boltz.CurrencyBtc || expectedAmount > nursery.maxZeroConfAmount {
-			confirmed, err := nursery.onchain.IsTransactionConfirmed(currency, output.TxId, true)
+
+		output, err := nursery.chooseDirectOutput(swap, feeEstimations, outputs)
+		if err != nil {
+			return err
+		}
+		if output == nil {
+			return nil
+		}
+
+		if swap.Pair.To == boltz.CurrencyBtc || output.Value > nursery.maxZeroConfAmount {
+			confirmed, err := nursery.onchain.IsTransactionConfirmed(swap.Pair.To, output.TxId, true)
 			if !errors.Is(err, errors.ErrUnsupported) {
 				if err != nil {
 					return fmt.Errorf("is transaction confirmed: %s", err)
@@ -277,6 +352,10 @@ func (nursery *Nursery) handleReverseSwapDirectPayment(swap *database.ReverseSwa
 					return nil
 				}
 			}
+		}
+
+		if err := tx.SetReverseSwapClaimTransactionId(swap, output.TxId, 0); err != nil {
+			return fmt.Errorf("set paid at: %s", err)
 		}
 		if err := tx.SetReverseSwapPaidAt(swap, time.Now()); err != nil {
 			return fmt.Errorf("set paid at: %s", err)
@@ -305,77 +384,40 @@ func (nursery *Nursery) checkExternalReverseSwaps(currency boltz.Currency, txId 
 	if err != nil {
 		return err
 	}
-	var swapsByClaimAddress = make(map[string][]*database.ReverseSwap)
 	for _, swap := range reverseSwaps {
-		if swap.ExternalPay && swap.ClaimAddress != "" {
-			swapsByClaimAddress[swap.ClaimAddress] = append(swapsByClaimAddress[swap.ClaimAddress], swap)
+		if !swap.ExternalPay || swap.ClaimAddress == "" {
+			continue
 		}
-	}
-	for claimAddress, swaps := range swapsByClaimAddress {
-		checked, err := nursery.checkSwapsWallet(swaps)
+		checked, err := nursery.checkSwapsWallet(swap)
 		if err != nil {
 			return err
 		}
 		// ignore external adresses if we are looking for a specific id
 		if !checked && txId == "" {
-			outputs, err := nursery.onchain.GetUnspentOutputs(currency, claimAddress)
+			outputs, err := nursery.onchain.GetUnspentOutputs(currency, swap.ClaimAddress)
 			if err != nil {
 				return err
 			}
-			if len(swaps) > 1 {
-				logger.Warnf("Multiple swaps for external claim address %s, can not tell which one to use", claimAddress)
-			} else {
-				for _, output := range outputs {
-					nursery.handleReverseSwapDirectPayment(swaps[0], output)
-				}
-			}
+			nursery.handleReverseSwapDirectPayments(swap, outputs)
 		}
 	}
 	return nil
 }
 
-func (nursery *Nursery) checkSwapsWallet(swaps []*database.ReverseSwap) (bool, error) {
-	walletId := swaps[0].WalletId
-	if walletId != nil {
-		swapWallet, err := nursery.onchain.GetAnyWallet(onchain.WalletChecker{Id: walletId, AllowReadonly: true})
+func (nursery *Nursery) checkSwapsWallet(swap *database.ReverseSwap) (bool, error) {
+	if swap.WalletId != nil {
+		swapWallet, err := nursery.onchain.GetAnyWallet(onchain.WalletChecker{Id: swap.WalletId, AllowReadonly: true})
 		if err != nil {
 			return false, err
 		}
-		outputs, err := swapWallet.GetOutputs(swaps[0].ClaimAddress)
+		outputs, err := swapWallet.GetOutputs(swap.ClaimAddress)
 		if err != nil {
 			if errors.Is(err, errors.ErrUnsupported) {
 				return false, nil
 			}
 			return true, err
 		}
-		slices.SortFunc(swaps, func(a, b *database.ReverseSwap) int {
-			return cmp.Compare(a.OnchainAmount, b.OnchainAmount)
-		})
-		slices.SortFunc(outputs, func(a, b *onchain.Output) int {
-			return cmp.Compare(a.Value, b.Value)
-		})
-		for _, swap := range swaps {
-			var chosenOutput *onchain.Output
-			for _, output := range outputs {
-				found, err := nursery.database.QueryReverseSwapByClaimTransaction(output.TxId)
-				if err == nil && found.Id != swap.Id {
-					continue
-				} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
-					logger.Errorf("could not query swap by claim tx: %s", err)
-				}
-				if output.Value <= swap.OnchainAmount || chosenOutput == nil {
-					// try to go match as close possible to the output value
-					// its important that we sorted both swaps and outputs by amount above
-					chosenOutput = output
-				} else {
-					break
-				}
-			}
-			if chosenOutput == nil {
-				return true, nil
-			}
-			nursery.handleReverseSwapDirectPayment(swap, chosenOutput)
-		}
+		nursery.handleReverseSwapDirectPayments(swap, outputs)
 		return true, nil
 	}
 	return false, nil

--- a/internal/onchain/wallet/wallet_test.go
+++ b/internal/onchain/wallet/wallet_test.go
@@ -28,6 +28,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestWallet_BumpTransactionFee(t *testing.T) {
+	// we sleep here to avoid a race where tx doesn't get confirmed by a block we mined, causing the tx to be confirmed
+	time.Sleep(10 * time.Second)
 	wallet := getWallet(boltz.CurrencyBtc)
 	someAddress := test.GetNewAddress(test.BtcCli)
 	amount := int64(1000)

--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -1826,25 +1826,6 @@ func TestDirectReverseSwapPayments(t *testing.T) {
 	fundedWallet(t, client, boltzrpc.Currency_LBTC)
 	defer stop()
 
-	t.Run("Multiple", func(t *testing.T) {
-		address := test.GetNewAddress(test.LiquidCli)
-		externalPay := true
-		request := &boltzrpc.CreateReverseSwapRequest{
-			Pair: &boltzrpc.Pair{
-				From: boltzrpc.Currency_BTC,
-				To:   boltzrpc.Currency_LBTC,
-			},
-			ExternalPay: &externalPay,
-			Amount:      maxZeroConfAmount,
-			Address:     address,
-		}
-		_, err := client.CreateReverseSwap(request)
-		require.NoError(t, err)
-		request.Address = address
-		_, err = client.CreateReverseSwap(request)
-		require.Error(t, err)
-	})
-
 	tt := []struct {
 		desc     string
 		zeroconf bool
@@ -1900,7 +1881,7 @@ func TestDirectReverseSwapPayments(t *testing.T) {
 
 			_, statusStream := swapStream(t, client, reverseSwap.Id)
 			// it only gets to mempool state on liquid since its using gdk - btc uses the node wallet
-			if !tc.zeroconf && tc.currency == boltzrpc.Currency_LBTC {
+			if !tc.zeroconf {
 				statusStream(boltzrpc.SwapState_PENDING, boltz.TransactionDirectMempool)
 			}
 			confirmed = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling direct transactions in reverse swaps, including selection of suitable outputs and special handling for Liquid currency.
  * Introduced the ability to derive blinding keys for Liquid wallet addresses.
  * Implemented a new method to query reverse swaps by claim address.

* **Bug Fixes**
  * Prevented creation of multiple pending reverse swaps with the same claim address.

* **Refactor**
  * Separated fee estimation logic from amount checking for improved modularity.
  * Simplified and improved the logic for processing and checking reverse swaps.

* **Tests**
  * Added tests for direct output selection and updated tests to verify prevention of duplicate claim addresses in reverse swaps.
  * Re-enabled and updated Liquid-related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->