### PR TITLE
fix: dont require amount param when sending all wallet funds

### DIFF
--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -1862,7 +1862,7 @@ func (server *routedBoltzServer) WalletSend(ctx context.Context, request *boltzr
 	if request.Address == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "address required")
 	}
-	if request.Amount == 0 {
+	if request.Amount == 0 && !request.GetSendAll() {
 		return nil, status.Errorf(codes.InvalidArgument, "amount required")
 	}
 	txId, err := sendWallet.SendToAddress(onchain.WalletSendArgs{

--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -2075,7 +2075,6 @@ func TestWalletSendReceive(t *testing.T) {
 				desc: "SendAll",
 				request: &boltzrpc.WalletSendRequest{
 					Address: "address",
-					Amount:  1000,
 					SendAll: &sendAll,
 				},
 				result: "txid",
@@ -2083,7 +2082,6 @@ func TestWalletSendReceive(t *testing.T) {
 				setup: func(mockWallet *onchainmock.MockWallet) {
 					mockWallet.EXPECT().SendToAddress(onchain.WalletSendArgs{
 						Address:     "address",
-						Amount:      1000,
 						SatPerVbyte: defaultEstimate,
 						SendAll:     sendAll,
 					}).Return("txid", nil)


### PR DESCRIPTION
test case also had amount specified, which was hiding the issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sending the entire wallet balance ("Send All") now works correctly without requiring an explicit amount.

* **Tests**
  * Updated tests to reflect the improved "Send All" wallet send behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->