### PR TITLE
Add `cargo` to build instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ docker exec boltz-client boltzcli getinfo
 
 ### Building from source
 
-To build, [Go](https://go.dev/) version `1.21` or higher is required. Boltz Client also has C dependencies, which means a C compiler has to be installed to compile the daemon successfully.
+To build, you need [Go](https://go.dev/) ≥ 1.21, the Rust toolchain (including [cargo](https://doc.rust-lang.org/cargo/) and `rustc`), and a C compiler such as `gcc` for the native dependencies used by the daemon.
 
 Boltz Client depends on [GDK](https://github.com/Blockstream/gdk) by blockstream, which can be either dynamically or statically linked. The recommended way to build from source is linking dynamically as a static link requires compiling gdk as well.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions to specify that Rust's cargo and a C compiler like gcc are required, in addition to Go 1.21 or higher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->