### PR TITLE
docs: enable search detailed view

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,9 @@ export default defineConfig({
     logo: "/assets/logo.svg",
     search: {
       provider: "local",
+      options: {
+        detailedView: true
+      }
     },
     nav: [{ text: "🏠 Docs Home", link: docsRoot, target: "_self" }],
     sidebar: [


### PR DESCRIPTION
Changing default search view from:
<img width="1137" height="420" alt="Screenshot from 2025-07-18 16-12-01" src="https://github.com/user-attachments/assets/09d7430e-8c73-4c5a-9b24-da8cde529b36" />

To:
<img width="1137" height="581" alt="Screenshot from 2025-07-18 16-12-09" src="https://github.com/user-attachments/assets/a7c08c2e-78e0-48cd-aead-bdcdfe40208a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled detailed view mode for local search results in the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->