### PR TITLE
feat: validate refund address when creating submarine swap

### DIFF
--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -2450,6 +2450,16 @@ func TestSwap(t *testing.T) {
 							return swapStream(t, admin, swap.Id)
 						}
 
+						t.Run("InvalidRefundAddress", func(t *testing.T) {
+							invalidAddress := "invalid"
+							_, err := admin.CreateSwap(&boltzrpc.CreateSwapRequest{
+								Pair:          pair,
+								RefundAddress: &invalidAddress,
+							})
+							requireCode(t, err, codes.InvalidArgument)
+							require.ErrorContains(t, err, "invalid refund address")
+						})
+
 						t.Run("Script", func(t *testing.T) {
 							boltzApi.DisablePartialSignatures = true
 							t.Cleanup(func() {


### PR DESCRIPTION
closes: #510 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for custom refund addresses when creating swaps, ensuring only valid addresses are accepted.

* **Tests**
  * Added a test to verify that creating a swap with an invalid refund address correctly returns an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->