### PR TITLE
fix: lwk create send lock

### DIFF
--- a/internal/onchain/liquid-wallet/wallet.go
+++ b/internal/onchain/liquid-wallet/wallet.go
@@ -33,6 +33,7 @@ type Wallet struct {
 	syncCancel context.CancelFunc
 	syncWait   sync.WaitGroup
 	syncLock   sync.Mutex
+	sendLock   sync.Mutex
 }
 
 type EsploraConfig struct {
@@ -493,6 +494,9 @@ func (w *Wallet) createTransaction(args onchain.WalletSendArgs) (*lwk.Transactio
 }
 
 func (w *Wallet) SendToAddress(args onchain.WalletSendArgs) (string, error) {
+	w.sendLock.Lock()
+	defer w.sendLock.Unlock()
+
 	tx, err := w.createTransaction(args)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
we still need an explicit lock in the send function to avoid double
spends


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of sending transactions by preventing simultaneous transaction creation and broadcasting within the same wallet instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->