### PR TITLE
fix: boltz api timeout

### DIFF
--- a/internal/rpcserver/server.go
+++ b/internal/rpcserver/server.go
@@ -383,6 +383,7 @@ func initBoltz(cfg *config.Config, network *boltz.Network) (*boltz.Api, error) {
 		transport.Proxy = http.ProxyURL(proxy)
 		boltzApi.Client = http.Client{
 			Transport: transport,
+			Timeout:   30 * time.Second,
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 30-second total timeout for Boltz API requests when a proxy is enabled, preventing stalls on slow or unreachable proxy connections. Improves reliability and responsiveness by ensuring requests fail within a bounded time, reducing UI hangs and improving user feedback during network disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->