### PR TITLE
chore: bump go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PKG := github.com/BoltzExchange/boltz-client/v2
 VERSION := 2.8.3
 GDK_VERSION = 0.75.1
-GO_VERSION := 1.24.2
+GO_VERSION := 1.24.6
 RUST_VERSION := 1.82.0
 
 PKG_BOLTZD := $(PKG)/cmd/boltzd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BoltzExchange/boltz-client/v2
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
fixes https://github.com/advisories/GHSA-j5pm-7495-qmr3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded the Go toolchain to version 1.24.6 across build and container workflows, aligning environments and improving stability and security posture.

* Build
  * Updated the module’s Go version directive to match the new toolchain, ensuring consistent builds across local and CI environments.

* Notes
  * No user-facing functionality changes. Existing features and behavior remain unchanged, with improvements limited to underlying build reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->