### PR TITLE
fix: backend log typo

### DIFF
--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -2053,7 +2053,7 @@ func (server *routedBoltzServer) unlock(password string) error {
 		for {
 			version, err := server.boltz.GetVersion()
 			if err != nil {
-				logger.Errorf("Boltz backend be unavailable, retrying in 10 seconds: %v", err)
+				logger.Errorf("Boltz backend is unavailable, retrying in 10 seconds: %v", err)
 				server.state = stateUnavailable
 				time.Sleep(time.Second * 10)
 			} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a grammatical error in the retry log message shown when the backend is unavailable, improving clarity and professionalism of operational logs. This helps operators quickly understand the service state during unlock retries and during incidents. No functional changes or impact to workflows; only the log output text has been updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->