### PR TITLE
fix: Dockerfile base image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder /boltz-client/boltzd /
 COPY --from=builder /boltz-client/boltzcli /
 
 # Start a new, final image.
-FROM ubuntu:jammy AS final
+FROM ubuntu:noble AS final
 
 RUN apt update && apt install ca-certificates -y && rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PKG := github.com/BoltzExchange/boltz-client/v2
 VERSION := 2.8.4
 GDK_VERSION = 0.75.1
-GO_VERSION := 1.24.6
+GO_VERSION := 1.24.7-bookworm
 RUST_VERSION := 1.82.0
 
 PKG_BOLTZD := $(PKG)/cmd/boltzd


### PR DESCRIPTION
The base image of the builder stage had a higher glibc version than the base container of the runtime stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime base image to Ubuntu 24.04 (Noble) for container builds.
  * Bumped Go toolchain version used in Docker builds to 1.24.7-bookworm.
  * No changes to exposed ports, entrypoint, or runtime behavior expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->