### PR TITLE
cli: remove swap timeout hint for external lockups

### DIFF
--- a/cmd/boltzcli/commands.go
+++ b/cmd/boltzcli/commands.go
@@ -1194,7 +1194,7 @@ func createSwap(ctx *cli.Context) error {
 		return nil
 	} else {
 		if externalPay {
-			printDeposit(swap.ExpectedAmount, swap.Address, swap.TimeoutHours, uint64(swap.TimeoutBlockHeight), pairInfo.Limits)
+			printDeposit(swap.ExpectedAmount, swap.Address, pairInfo.Limits)
 		}
 		fmt.Println()
 		fmt.Println("Swap ID:", swap.Id)
@@ -1344,13 +1344,7 @@ func createChainSwap(ctx *cli.Context) error {
 	}
 
 	if externalPay {
-		height := info.BlockHeights.Btc
-		if pair.From == boltzrpc.Currency_LBTC {
-			height = info.BlockHeights.GetLiquid()
-		}
-		timeout := swap.FromData.TimeoutBlockHeight
-		timeoutHours := boltz.BlocksToHours(timeout-height, serializers.ParseCurrency(&pair.From))
-		printDeposit(amount, swap.FromData.LockupAddress, float32(timeoutHours), uint64(timeout), pairInfo.Limits)
+		printDeposit(amount, swap.FromData.LockupAddress, pairInfo.Limits)
 		fmt.Println()
 	}
 

--- a/cmd/boltzcli/utils.go
+++ b/cmd/boltzcli/utils.go
@@ -100,7 +100,7 @@ func printFees(fees *boltzrpc.SwapFees, amount uint64) {
 	fmt.Println()
 }
 
-func printDeposit(amount uint64, address string, hours float32, blockHeight uint64, limits *boltzrpc.Limits) {
+func printDeposit(amount uint64, address string, limits *boltzrpc.Limits) {
 	var amountString string
 	if amount == 0 {
 		amountString = fmt.Sprintf("between %d and %d satoshis", limits.Minimal, limits.Maximal)
@@ -108,8 +108,7 @@ func printDeposit(amount uint64, address string, hours float32, blockHeight uint
 		amountString = utils.Satoshis(amount)
 	}
 
-	fmt.Printf("Please deposit %s into %s in the next ~%.1f hours (block height %d)\n",
-		amountString, address, hours, blockHeight)
+	fmt.Printf("Please deposit %s into %s\n", amountString, address)
 }
 
 var errNotNumber = errors.New("not a valid number")


### PR DESCRIPTION
taproot timeouts are so big that this extra info isn't gonna affect any
user and is currently misleading for usage of pro
