### PR TITLE
ci: reduce btc -> btc regtest timeouts

### DIFF
--- a/regtest.patch
+++ b/regtest.patch
@@ -1,7 +1,24 @@
 diff --git a/data/backend/boltz.conf b/data/backend/boltz.conf
-index 6129eba..ccc3014 100755
+index 6129eba..f39f3dd 100755
 --- a/data/backend/boltz.conf
 +++ b/data/backend/boltz.conf
+@@ -36,11 +36,11 @@ maxSwapAmount = 40_294_967
+ minSwapAmount = 50_000
+ 
+   [pairs.timeoutDelta]
+-  chain = 1440
+-  reverse = 1440
+-  swapMinimal = 1440
+-  swapMaximal = 2880
+-  swapTaproot = 10080
++  chain = 180
++  reverse = 180
++  swapTaproot = 450
++  swapMinimal = 400
++  swapMaximal = 450
+ 
+ [[pairs]]
+ base = "L-BTC"
 @@ -59,11 +59,11 @@ minSwapAmount = 100
    minSwapAmount = 25_000
  
@@ -11,9 +28,9 @@ index 6129eba..ccc3014 100755
 -  swapMinimal = 1440
 -  swapMaximal = 2880
 -  swapTaproot = 10080
-+  chain = 400
-+  reverse = 400
-+  swapTaproot = 750
++  chain = 180
++  reverse = 180
++  swapTaproot = 450
 +  swapMinimal = 400
 +  swapMaximal = 450
  


### PR DESCRIPTION
410 minutes -> 41 blocks, absolute minimal as of now (lnd min final cltv
18 + buffer when paying 3 + boltz delta 20)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Primary trading base switched to L-BTC; BTC added as supported currency.

- Chores
  - Global minimum swap amount raised to 50,000 while select pairs retain a lower per-pair minimum (25,000).
  - Swap timeouts shortened for faster expiries and retries (e.g., chain/reverse ≈180, taproot ≈450, minimal ≈400, maximal ≈450).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->