### PR TITLE
refactor: rm `RequireConfirmed` flag when finding output

### DIFF
--- a/internal/nursery/chain.go
+++ b/internal/nursery/chain.go
@@ -72,7 +72,6 @@ func chainOutputArgs(data *database.ChainSwapData) onchain.OutputArgs {
 
 func (nursery *Nursery) getChainSwapClaimOutput(swap *database.ChainSwap) *Output {
 	info := chainOutputArgs(swap.ToData)
-	info.RequireConfirmed = !swap.AcceptZeroConf
 	info.ExpectedAmount = swap.ToData.Amount
 	return &Output{
 		OutputDetails: &boltz.OutputDetails{

--- a/internal/nursery/reverse.go
+++ b/internal/nursery/reverse.go
@@ -110,12 +110,11 @@ func (nursery *Nursery) getReverseSwapClaimOutput(reverseSwap *database.ReverseS
 		},
 		walletId: reverseSwap.WalletId,
 		outputArgs: onchain.OutputArgs{
-			TransactionId:    reverseSwap.LockupTransactionId,
-			Currency:         reverseSwap.Pair.To,
-			Address:          lockupAddress,
-			BlindingKey:      reverseSwap.BlindingKey,
-			ExpectedAmount:   reverseSwap.OnchainAmount,
-			RequireConfirmed: !reverseSwap.AcceptZeroConf,
+			TransactionId:  reverseSwap.LockupTransactionId,
+			Currency:       reverseSwap.Pair.To,
+			Address:        lockupAddress,
+			BlindingKey:    reverseSwap.BlindingKey,
+			ExpectedAmount: reverseSwap.OnchainAmount,
 		},
 		setTransaction: func(transactionId string, fee uint64) error {
 			if err := nursery.database.SetReverseSwapClaimTransactionId(reverseSwap, transactionId, fee); err != nil {

--- a/internal/onchain/onchain.go
+++ b/internal/onchain/onchain.go
@@ -383,12 +383,11 @@ func (onchain *Onchain) GetUnspentOutputs(currency boltz.Currency, address strin
 }
 
 type OutputArgs struct {
-	TransactionId    string
-	Currency         boltz.Currency
-	Address          string
-	BlindingKey      *btcec.PrivateKey
-	ExpectedAmount   uint64
-	RequireConfirmed bool
+	TransactionId  string
+	Currency       boltz.Currency
+	Address        string
+	BlindingKey    *btcec.PrivateKey
+	ExpectedAmount uint64
 }
 
 type OutputResult struct {
@@ -412,17 +411,6 @@ func (onchain *Onchain) FindOutput(info OutputArgs) (*OutputResult, error) {
 
 	if info.ExpectedAmount != 0 && value < info.ExpectedAmount {
 		return nil, fmt.Errorf("locked up less onchain coins than expected: %d < %d", value, info.ExpectedAmount)
-	}
-	if info.RequireConfirmed {
-		confirmed, err := onchain.IsTransactionConfirmed(info.Currency, info.TransactionId, false)
-		if !errors.Is(err, errors.ErrUnsupported) {
-			if err != nil {
-				return nil, errors.New("Could not check if lockup transaction is confirmed: " + err.Error())
-			}
-			if !confirmed {
-				return nil, ErrNotConfirmed
-			}
-		}
 	}
 
 	return &OutputResult{


### PR DESCRIPTION
since we know check for confirmation when choosing claimable swaps, we
dont have to do it a second time when creating the tx. this also causes
the old test case to stop working since we dont error and just ignore.
those can be safely removed since the confirmation check is now covered
elsewhere


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed zero-confirmation transaction support from swap claim operations; confirmed transactions are now required for all claim eligibility checks

* **Tests**
  * Updated test suites to remove zero-confirmation scenarios and align with new transaction confirmation requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->