### PR TITLE
fix: only try refunding submarine swap if funds were locked

### DIFF
--- a/internal/nursery/swap.go
+++ b/internal/nursery/swap.go
@@ -381,13 +381,16 @@ func (nursery *Nursery) handleSwapStatus(swap *database.Swap, status boltz.SwapS
 				handleError(err.Error())
 				return
 			}
+
+			if swap.LockupTransactionId != "" {
+				logger.Infof("Swap %s failed, trying to refund cooperatively", swap.Id)
+				if _, err := nursery.RefundSwaps(swap.Pair.From, []*database.Swap{swap}, nil); err != nil {
+					handleError("Could not refund Swap " + swap.Id + ": " + err.Error())
+					return
+				}
+			}
 		}
 
-		logger.Infof("Swap %s failed, trying to refund cooperatively", swap.Id)
-		if _, err := nursery.RefundSwaps(swap.Pair.From, []*database.Swap{swap}, nil); err != nil {
-			handleError("Could not refund Swap " + swap.Id + ": " + err.Error())
-			return
-		}
 	}
 	nursery.sendSwapUpdate(*swap)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap failure handling: the system now validates the presence of a valid lockup transaction before attempting cooperative refunds, preventing unnecessary refund attempts on failed swaps.
  * Preserves prior error handling when a lockup transaction exists, improving reliability and reducing spurious operations during swap failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->