### PR TITLE
fix(electrum): subscribe to headers on creation

### DIFF
--- a/internal/electrum/electrum_test.go
+++ b/internal/electrum/electrum_test.go
@@ -3,8 +3,8 @@
 package electrum_test
 
 import (
-	"context"
 	"testing"
+	"time"
 
 	"github.com/BoltzExchange/boltz-client/v2/internal/electrum"
 	"github.com/BoltzExchange/boltz-client/v2/internal/test"
@@ -24,25 +24,22 @@ func client(t *testing.T) *electrum.Client {
 
 func TestBlockStream(t *testing.T) {
 	client := client(t)
-	blocks := make(chan *onchain.BlockEpoch)
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		err := client.RegisterBlockListener(ctx, blocks)
-		require.NoError(t, err)
-		close(blocks)
-	}()
-	block := <-blocks
-	require.NotZero(t, block.Height)
-	test.MineBlock()
-	block = <-blocks
-	require.NotZero(t, block.Height)
-	cancel()
-	_, ok := <-blocks
-	require.False(t, ok)
 
-	height, err := client.GetBlockHeight()
-	require.NoError(t, err)
-	require.Equal(t, block.Height, height)
+	var height uint32
+	require.Eventually(t, func() bool {
+		var err error
+		height, err = client.GetBlockHeight()
+		require.NoError(t, err)
+		return height != 0
+	}, 10*time.Second, 100*time.Millisecond)
+
+	test.MineBlock()
+
+	require.Eventually(t, func() bool {
+		newHeight, err := client.GetBlockHeight()
+		require.NoError(t, err)
+		return newHeight == height+1
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestEstimateFee(t *testing.T) {


### PR DESCRIPTION
previously relied on `RegisterBlockListener` from the old onchain
interface to be called


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the public block-listener API with an internal header subscription; block height is now tracked atomically and managed internally.

* **Tests**
  * Simplified tests to poll and assert block height changes sequentially (waiting for initial height and verifying increments) instead of relying on asynchronous channel listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->