### PR TITLE
fix(gdk): dont apply default regtest electrum on every network

### DIFF
--- a/internal/onchain/wallet/wallet.go
+++ b/internal/onchain/wallet/wallet.go
@@ -294,7 +294,7 @@ func (wallet *Wallet) Connect() error {
 	switch wallet.Currency {
 	case boltz.CurrencyBtc:
 		electrum = config.Electrum.Btc
-		if electrum == nil {
+		if electrum == nil && config.Network == boltz.Regtest {
 			electrum = onchain.RegtestElectrumConfig.Btc
 		}
 		switch config.Network {
@@ -309,7 +309,7 @@ func (wallet *Wallet) Connect() error {
 		}
 	case boltz.CurrencyLiquid:
 		electrum = config.Electrum.Liquid
-		if electrum == nil {
+		if electrum == nil && config.Network == boltz.Regtest {
 			electrum = onchain.RegtestElectrumConfig.Liquid
 		}
 		switch config.Network {


### PR DESCRIPTION
regression was introduce in:
919ea69e1be892944c4c3cb9c985e1cbcaf2fb74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet connection handling for Bitcoin and Liquid currencies on Regtest networks by ensuring proper default configurations are applied when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->