### PR TITLE
fix: also update submarine lockup tx on `transaction.confirmed`

### DIFF
--- a/internal/nursery/swap.go
+++ b/internal/nursery/swap.go
@@ -160,7 +160,7 @@ func (nursery *Nursery) handleSwapStatus(swap *database.Swap, status boltz.SwapS
 	// if we're at invoice.set, there is no lockup transaction yet.
 	// since there is the possibility that `transaction.mempool` is transitioned through while the client is offline
 	// we have to check if the transaction is empty aswell
-	if parsedStatus != boltz.InvoiceSet && (parsedStatus == boltz.TransactionMempool || swap.LockupTransactionId == "") {
+	if parsedStatus != boltz.InvoiceSet && (parsedStatus == boltz.TransactionMempool || parsedStatus == boltz.TransactionConfirmed || swap.LockupTransactionId == "") {
 		swapTransactionResponse, err := nursery.boltz.GetSwapTransaction(swap.Id)
 		if err != nil {
 			var boltzErr boltz.Error


### PR DESCRIPTION
the tx can be a different one than we got on `transaction.mempool`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockup transaction retrieval logic to recognize additional transaction states. The system now properly fetches and processes lockup transactions across a broader set of transaction confirmation states, enhancing reliability and consistency of transaction processing during swap operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->