### PR TITLE
refactor: always use mainnet for rescue keychain

### DIFF
--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -2380,7 +2380,7 @@ func (server *routedBoltzServer) SetSwapMnemonic(ctx context.Context, request *b
 	}
 
 	// Validate the mnemonic by trying to derive a key from it
-	_, err := boltz.DeriveKey(mnemonic, 0, server.network.Btc)
+	_, err := boltz.DeriveKey(mnemonic, 0)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid mnemonic: %s", err)
 	}
@@ -2511,7 +2511,7 @@ func (server *routedBoltzServer) newKeys() (*btcec.PrivateKey, *btcec.PublicKey,
 		return nil, nil, status.Errorf(codes.FailedPrecondition, "swap mnemonic not set")
 	}
 
-	privateKey, err = boltz.DeriveKey(mnemonic.Mnemonic, mnemonic.LastKeyIndex, server.network.Btc)
+	privateKey, err = boltz.DeriveKey(mnemonic.Mnemonic, mnemonic.LastKeyIndex)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -3395,7 +3395,7 @@ func TestSwapMnemonic(t *testing.T) {
 		mnemonic, err := client.GetSwapMnemonic()
 		require.NoError(t, err)
 
-		privateKey, err := boltz.DeriveKey(mnemonic.Mnemonic, expectedKeyIndex, boltz.Regtest.Btc)
+		privateKey, err := boltz.DeriveKey(mnemonic.Mnemonic, expectedKeyIndex)
 		require.NoError(t, err)
 		require.Equal(t, hex.EncodeToString(privateKey.Serialize()), swapInfo.Swap.PrivateKey)
 	}

--- a/pkg/boltz/rescue.go
+++ b/pkg/boltz/rescue.go
@@ -9,13 +9,14 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
-func mnemonicToHdKey(mnemonic string, network *chaincfg.Params) (*hdkeychain.ExtendedKey, error) {
+func mnemonicToHdKey(mnemonic string) (*hdkeychain.ExtendedKey, error) {
 	seed, err := bip39.NewSeedWithErrorChecking(mnemonic, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate seed: %w", err)
 	}
 
-	return hdkeychain.NewMaster(seed, network)
+	// boltz backend and web app also use main net params across all networks
+	return hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
 }
 
 func deriveKey(hdKey *hdkeychain.ExtendedKey, index uint32) (*hdkeychain.ExtendedKey, error) {
@@ -34,8 +35,8 @@ func deriveKey(hdKey *hdkeychain.ExtendedKey, index uint32) (*hdkeychain.Extende
 	return extendedKey, nil
 }
 
-func DeriveKey(mnemonic string, index uint32, network *chaincfg.Params) (*btcec.PrivateKey, error) {
-	hdKey, err := mnemonicToHdKey(mnemonic, network)
+func DeriveKey(mnemonic string, index uint32) (*btcec.PrivateKey, error) {
+	hdKey, err := mnemonicToHdKey(mnemonic)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/boltz/rescue_test.go
+++ b/pkg/boltz/rescue_test.go
@@ -3,19 +3,18 @@ package boltz
 import (
 	"testing"
 
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDeriveKey(t *testing.T) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 	lastKeyIndex := uint32(0)
-	firstKey, err := DeriveKey(mnemonic, lastKeyIndex, &chaincfg.RegressionNetParams)
+	firstKey, err := DeriveKey(mnemonic, lastKeyIndex)
 	require.NoError(t, err)
 	require.NotNil(t, firstKey)
 
 	lastKeyIndex = 1
-	secondKey, err := DeriveKey(mnemonic, lastKeyIndex, &chaincfg.RegressionNetParams)
+	secondKey, err := DeriveKey(mnemonic, lastKeyIndex)
 	require.NoError(t, err)
 	require.NotNil(t, secondKey)
 	require.NotEqual(t, firstKey.PubKey().SerializeCompressed(), secondKey.PubKey().SerializeCompressed())


### PR DESCRIPTION
might not be best practice but is consistent with backend and webapp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined key derivation by removing unnecessary parameters, reducing code complexity while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->