### PR TITLE
fix: full scan wallet on import

### DIFF
--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -1461,7 +1461,7 @@ func (server *routedBoltzServer) importWallet(ctx context.Context, credentials *
 	}
 
 	// TODO: maybe allow returning without sync here
-	return imported.Sync()
+	return imported.FullScan()
 }
 
 func (server *routedBoltzServer) ImportWallet(ctx context.Context, request *boltzrpc.ImportWalletRequest) (*boltzrpc.Wallet, error) {


### PR DESCRIPTION
explicit fullscan has only been added recently, so the import is now
using the wrong function


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wallet import to perform comprehensive initialization, ensuring all wallet data is properly loaded and verified during the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->