### PR TITLE
chore: add standalone mode hint in error message

### DIFF
--- a/internal/rpcserver/server.go
+++ b/internal/rpcserver/server.go
@@ -152,7 +152,7 @@ func (server *routedBoltzServer) initLightning(cfg *config.Config) error {
 	} else if isLndConfigured {
 		server.lightning = cfg.LND
 	} else {
-		return errors.New("No Lightning node configured. Start with --standalone to run without connecting to a Lightning node.")
+		return errors.New("no Lightning node configured, start with --standalone to run without connecting to a Lightning node")
 	}
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message shown when no lightning node is configured: the message is now capitalized, more user-facing, and explicitly suggests starting the application in standalone mode to reduce confusion and provide clearer guidance on available startup options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->