### PR TITLE
refactor: dont try to refund on `ERROR` state

### DIFF
--- a/internal/database/swap.go
+++ b/internal/database/swap.go
@@ -323,12 +323,12 @@ SELECT * FROM swaps
 WHERE fromCurrency = ?
   AND swaps.lockupTransactionId != ''
   AND swaps.refundTransactionId == ''
-  AND (state IN (?, ?) OR (state != ? AND swaps.timeoutBlockheight < ?))
+  AND (state = ? OR (state != ? AND swaps.timeoutBlockheight < ?))
 `
 
 func (database *Database) QueryRefundableSwaps(tenantId *Id, currency boltz.Currency, currentBlockHeight uint32) ([]*Swap, error) {
 	query := refundableSwapsQuery
-	values := []any{currency, boltzrpc.SwapState_SERVER_ERROR, boltzrpc.SwapState_ERROR, boltzrpc.SwapState_SUCCESSFUL, currentBlockHeight}
+	values := []any{currency, boltzrpc.SwapState_SERVER_ERROR, boltzrpc.SwapState_SUCCESSFUL, currentBlockHeight}
 	if tenantId != nil {
 		query += " AND tenantId = ?"
 		values = append(values, tenantId)


### PR DESCRIPTION
it only indicated something has gone wrong in the client but that doesnt
deem it as refundable yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the criteria for identifying refundable swaps to more accurately reflect which transactions are eligible for refund based on their current state and timeout conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->