### PR TITLE
fix: add migration for legacy btc wallets

### DIFF
--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -21,7 +21,7 @@ type swapStatus struct {
 	status string
 }
 
-const latestSchemaVersion = 17
+const latestSchemaVersion = 18
 
 func (database *Database) migrate() error {
 	version, err := database.queryVersion()
@@ -615,6 +615,15 @@ func (database *Database) performMigration(tx *Transaction, oldVersion int) erro
 			mnemonic     VARCHAR PRIMARY KEY,
 			lastKeyIndex INT DEFAULT 0
 		);
+		`
+		if _, err := tx.Exec(migration); err != nil {
+			return err
+		}
+	case 17:
+		logMigration(oldVersion)
+
+		migration := `
+		UPDATE wallets SET legacy = TRUE WHERE currency = 'BTC';
 		`
 		if _, err := tx.Exec(migration); err != nil {
 			return err


### PR DESCRIPTION
since its introduction the legacy wallet has been left false for all new
wallets, so we have to make sure we flag the old btc wallets once more


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema with a migration that modifies wallet data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->