### PR TITLE
fix: check for transaction.refunded when querying claimable reverse swaps

### DIFF
--- a/internal/database/reverse.go
+++ b/internal/database/reverse.go
@@ -271,11 +271,12 @@ SELECT * FROM reverseSwaps
 WHERE toCurrency = ?
   AND reverseSwaps.lockupTransactionId != ''
   AND reverseSwaps.claimTransactionId == ''
+  AND reverseSwaps.status != ?
 `
 
 func (database *Database) QueryClaimableReverseSwaps(tenantId *Id, currency boltz.Currency) ([]*ReverseSwap, error) {
 	query := claimableSwapsQuery
-	values := []any{currency}
+	values := []any{currency, boltz.TransactionRefunded.String()}
 	if tenantId != nil {
 		query += " AND tenantId = ?"
 		values = append(values, *tenantId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined claimable reverse-swap logic to exclude refunded transactions, so refunded swaps no longer appear as available to claim.
  * Improves accuracy of the available-claim list, reducing false positives and preventing attempts to claim refunded items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->