### PR TITLE
feat: use p2tr when generating cln addresses

### DIFF
--- a/internal/cln/cln.go
+++ b/internal/cln/cln.go
@@ -245,12 +245,12 @@ func (c *Cln) PayInvoice(ctx context.Context, invoice string, feeLimit uint, tim
 
 func (c *Cln) NewAddress() (string, error) {
 	res, err := c.Client.NewAddr(context.Background(), &protos.NewaddrRequest{
-		//Addresstype: &protos.NewaddrRequest_BECH32,
+		Addresstype: protos.NewaddrRequest_P2TR.Enum(),
 	})
 	if err != nil {
 		return "", err
 	}
-	return *res.Bech32, nil
+	return res.GetP2Tr(), nil
 }
 
 func (c *Cln) PaymentStatus(paymentHash []byte) (*lightning.PaymentStatus, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated address generation to use Taproot (P2TR) address format instead of the previous format, improving compatibility and security for users generating new addresses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->