### PR TITLE
feat: ws channel and read buffers

### DIFF
--- a/pkg/boltz/ws.go
+++ b/pkg/boltz/ws.go
@@ -18,6 +18,8 @@ import (
 const reconnectInterval = 15 * time.Second
 const pingInterval = 30 * time.Second
 const pongWait = 5 * time.Second
+const readBufferSize = 1024 * 1024 // 1MB
+const updatesChannelBuffer = 50
 
 type SwapUpdate struct {
 	SwapStatusResponse `mapstructure:",squash"`
@@ -53,12 +55,13 @@ func (boltz *Api) NewWebsocket() *Websocket {
 	if ok {
 		dialer.Proxy = httpTransport.Proxy
 	}
+	dialer.ReadBufferSize = readBufferSize
 
 	return &Websocket{
 		apiUrl:            boltz.URL,
 		subscriptions:     make(chan bool),
 		dialer:            &dialer,
-		Updates:           make(chan SwapUpdate),
+		Updates:           make(chan SwapUpdate, updatesChannelBuffer),
 		reconnectInterval: reconnectInterval,
 	}
 }


### PR DESCRIPTION
If multiple big updates (like `transaction.mempool` which includes the entire tx hex) are incoming it can happen that some are swallowed since the default ws buffer is rather small and we didn't buffer the go channel sends either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized WebSocket connection handling with improved buffer management for better stability and message throughput.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->