### PR TITLE
fix: ignore unknown currencies

### DIFF
--- a/internal/nursery/chain.go
+++ b/internal/nursery/chain.go
@@ -164,9 +164,7 @@ func (nursery *Nursery) handleChainSwapError(swap *database.ChainSwap, err error
 	nursery.sendChainSwapUpdate(*swap)
 }
 
-func (nursery *Nursery) handleChainSwapStatus(swap *database.ChainSwap, status boltz.SwapStatusResponse) {
-	parsedStatus := boltz.ParseEvent(status.Status)
-
+func (nursery *Nursery) handleChainSwapStatus(swap *database.ChainSwap, parsedStatus boltz.SwapUpdateEvent, status boltz.SwapStatusResponse) {
 	isMempool := parsedStatus == boltz.TransactionMempool || parsedStatus == boltz.TransactionServerMempoool
 	if parsedStatus == swap.Status && !isMempool {
 		logger.Debugf("Status of Chain Swap %s is %s already", swap.Id, parsedStatus)

--- a/internal/nursery/nursery.go
+++ b/internal/nursery/nursery.go
@@ -230,12 +230,17 @@ func (nursery *Nursery) processUpdate(status boltz.SwapUpdate) error {
 	if status.Error != "" {
 		return fmt.Errorf("boltz could not find Swap %s: %s", status.Id, status.Error)
 	}
+	parsedStatus := boltz.ParseEvent(status.Status)
+	if parsedStatus == boltz.SwapUnknown {
+		logger.Warnf("Received unknown status for swap %s: %s", status.Id, status.Status)
+		return nil
+	}
 	if swap != nil {
-		nursery.handleSwapStatus(swap, status.SwapStatusResponse)
+		nursery.handleSwapStatus(swap, parsedStatus, status.SwapStatusResponse)
 	} else if reverseSwap != nil {
-		nursery.handleReverseSwapStatus(reverseSwap, status.SwapStatusResponse)
+		nursery.handleReverseSwapStatus(reverseSwap, parsedStatus, status.SwapStatusResponse)
 	} else if chainSwap != nil {
-		nursery.handleChainSwapStatus(chainSwap, status.SwapStatusResponse)
+		nursery.handleChainSwapStatus(chainSwap, parsedStatus, status.SwapStatusResponse)
 	}
 	return nil
 }

--- a/internal/nursery/reverse.go
+++ b/internal/nursery/reverse.go
@@ -173,9 +173,7 @@ func (nursery *Nursery) handleReverseSwapError(reverseSwap *database.ReverseSwap
 }
 
 // TODO: fail swap after "transaction.failed" event
-func (nursery *Nursery) handleReverseSwapStatus(reverseSwap *database.ReverseSwap, event boltz.SwapStatusResponse) {
-	parsedStatus := boltz.ParseEvent(event.Status)
-
+func (nursery *Nursery) handleReverseSwapStatus(reverseSwap *database.ReverseSwap, parsedStatus boltz.SwapUpdateEvent, event boltz.SwapStatusResponse) {
 	if parsedStatus == reverseSwap.Status {
 		logger.Debugf("Status of Reverse Swap %s is %s already", reverseSwap.Id, parsedStatus)
 		return

--- a/internal/nursery/swap.go
+++ b/internal/nursery/swap.go
@@ -142,9 +142,7 @@ func (nursery *Nursery) handleSwapError(swap *database.Swap, err error) {
 	nursery.sendSwapUpdate(*swap)
 }
 
-func (nursery *Nursery) handleSwapStatus(swap *database.Swap, status boltz.SwapStatusResponse) {
-	parsedStatus := boltz.ParseEvent(status.Status)
-
+func (nursery *Nursery) handleSwapStatus(swap *database.Swap, parsedStatus boltz.SwapUpdateEvent, status boltz.SwapStatusResponse) {
 	// transaction mempool can be sent multiple times in case of RBF
 	if parsedStatus == swap.Status && parsedStatus != boltz.TransactionMempool {
 		logger.Debugf("Status of Swap %s is %s already", swap.Id, parsedStatus)

--- a/pkg/boltz/api.go
+++ b/pkg/boltz/api.go
@@ -132,6 +132,15 @@ type SubmarinePair struct {
 
 type SubmarinePairs map[Currency]map[Currency]SubmarinePair
 
+func (pairs *SubmarinePairs) UnmarshalJSON(text []byte) error {
+	parsed, err := unmarshalCurrencies[SubmarinePair](text)
+	if err != nil {
+		return err
+	}
+	*pairs = parsed
+	return nil
+}
+
 type ReversePair struct {
 	Hash   string  `json:"hash"`
 	Rate   float64 `json:"rate"`
@@ -149,6 +158,15 @@ type ReversePair struct {
 }
 
 type ReversePairs map[Currency]map[Currency]ReversePair
+
+func (pairs *ReversePairs) UnmarshalJSON(text []byte) error {
+	parsed, err := unmarshalCurrencies[ReversePair](text)
+	if err != nil {
+		return err
+	}
+	*pairs = parsed
+	return nil
+}
 
 type ChainPair struct {
 	Hash   string  `json:"hash"`
@@ -171,6 +189,15 @@ type ChainPair struct {
 }
 
 type ChainPairs map[Currency]map[Currency]ChainPair
+
+func (pairs *ChainPairs) UnmarshalJSON(text []byte) error {
+	parsed, err := unmarshalCurrencies[ChainPair](text)
+	if err != nil {
+		return err
+	}
+	*pairs = parsed
+	return nil
+}
 
 type symbolMinerFees struct {
 	Normal  uint64 `json:"normal"`
@@ -812,4 +839,35 @@ func unmarshalJson(body io.ReadCloser, response interface{}) error {
 	}
 
 	return json.Unmarshal(rawBody, &response)
+}
+
+func unmarshalCurrencies[T any](text []byte) (map[Currency]map[Currency]T, error) {
+	var raw map[string]map[string]T
+	if err := json.Unmarshal(text, &raw); err != nil {
+		return nil, err
+	}
+
+	parsed := make(map[Currency]map[Currency]T, len(raw))
+	for fromRaw, toPairs := range raw {
+		// The backend might support currencies we don't know, so simply ignore them.
+		from, err := ParseCurrency(fromRaw)
+		if err != nil {
+			continue
+		}
+
+		parsedPairs := make(map[Currency]T, len(toPairs))
+		for toRaw, pair := range toPairs {
+			to, err := ParseCurrency(toRaw)
+			if err != nil {
+				continue
+			}
+			parsedPairs[to] = pair
+		}
+
+		if len(parsedPairs) > 0 {
+			parsed[from] = parsedPairs
+		}
+	}
+
+	return parsed, nil
 }

--- a/pkg/boltz/api_pairs_test.go
+++ b/pkg/boltz/api_pairs_test.go
@@ -1,0 +1,50 @@
+package boltz
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnknownCurrencies(t *testing.T) {
+	raw := []byte(`{
+		"BTC": {
+			"L-BTC": { "hash": "known-1" },
+			"DOGE": { "hash": "unknown-to" }
+		},
+		"DOGE": {
+			"BTC": { "hash": "unknown-from" }
+		}
+	}`)
+
+	t.Run("submarine", func(t *testing.T) {
+		var pairs SubmarinePairs
+		require.NoError(t, json.Unmarshal(raw, &pairs))
+
+		require.Contains(t, pairs, CurrencyBtc)
+		require.NotContains(t, pairs, Currency("DOGE"))
+		require.Contains(t, pairs[CurrencyBtc], CurrencyLiquid)
+		require.Equal(t, "known-1", pairs[CurrencyBtc][CurrencyLiquid].Hash)
+	})
+
+	t.Run("reverse", func(t *testing.T) {
+		var pairs ReversePairs
+		require.NoError(t, json.Unmarshal(raw, &pairs))
+
+		require.Contains(t, pairs, CurrencyBtc)
+		require.NotContains(t, pairs, Currency("DOGE"))
+		require.Contains(t, pairs[CurrencyBtc], CurrencyLiquid)
+		require.Equal(t, "known-1", pairs[CurrencyBtc][CurrencyLiquid].Hash)
+	})
+
+	t.Run("chain", func(t *testing.T) {
+		var pairs ChainPairs
+		require.NoError(t, json.Unmarshal(raw, &pairs))
+
+		require.Contains(t, pairs, CurrencyBtc)
+		require.NotContains(t, pairs, Currency("DOGE"))
+		require.Contains(t, pairs[CurrencyBtc], CurrencyLiquid)
+		require.Equal(t, "known-1", pairs[CurrencyBtc][CurrencyLiquid].Hash)
+	})
+}

--- a/pkg/boltz/events.go
+++ b/pkg/boltz/events.go
@@ -2,6 +2,8 @@ package boltz
 
 type SwapUpdateEvent int
 
+const SwapUnknown SwapUpdateEvent = -1
+
 const (
 	SwapCreated SwapUpdateEvent = iota
 	SwapExpired
@@ -79,7 +81,11 @@ func (event SwapUpdateEvent) String() string {
 }
 
 func ParseEvent(event string) SwapUpdateEvent {
-	return swapUpdateEventStrings[event]
+	parsed, ok := swapUpdateEventStrings[event]
+	if !ok {
+		return SwapUnknown
+	}
+	return parsed
 }
 
 func (event SwapUpdateEvent) IsCompletedStatus() bool {

--- a/pkg/boltz/events_test.go
+++ b/pkg/boltz/events_test.go
@@ -1,0 +1,13 @@
+package boltz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEvent(t *testing.T) {
+	assert.Equal(t, SwapCreated, ParseEvent("swap.created"))
+	assert.Equal(t, TransactionMempool, ParseEvent("transaction.mempool"))
+	assert.Equal(t, SwapUnknown, ParseEvent("not.a.real.event"))
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of currency-pair parsing to ignore unknown/unsupported currencies and preserve valid mappings.
  * Safer handling of unknown event/status values to avoid spurious processing and reduce incorrect state transitions.

* **Tests**
  * Added tests verifying handling of known and unknown currency entries across submarine, reverse, and chain pair parsing and event parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->