### PR TITLE
chore: rm unnecessary secpk submodule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/fatih/color v1.15.0
 	github.com/fiatjaf/go-lnurl v1.13.1
 	github.com/git-chglog/git-chglog v0.15.4
@@ -79,6 +78,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/decred/dcrd/lru v1.1.2 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
 	github.com/docker/docker v24.0.9+incompatible // indirect

--- a/pkg/boltz/musig.go
+++ b/pkg/boltz/musig.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	liquidtx "github.com/vulpemventures/go-elements/transaction"
 )
 
@@ -22,7 +22,7 @@ func NewSigningSession(tree *SwapTree) (*MusigSession, error) {
 		tree.ourKey,
 		false,
 		musig2.WithTweakedContext(tree.taprootTweak),
-		musig2.WithKnownSigners([]*secp256k1.PublicKey{tree.boltzKey, tree.ourKey.PubKey()}),
+		musig2.WithKnownSigners([]*btcec.PublicKey{tree.boltzKey, tree.ourKey.PubKey()}),
 	)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (session *MusigSession) Finalize(transaction Transaction, outputs []OutputD
 		return err
 	}
 
-	s := &secp256k1.ModNScalar{}
+	s := &btcec.ModNScalar{}
 	s.SetByteSlice(boltzSignature.PartialSignature)
 	partial := musig2.NewPartialSignature(s, nil)
 	haveFinal, err := session.CombineSig(&partial)


### PR DESCRIPTION
not required as direct dependency anymore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and refactored cryptographic type usage for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->