### PR TITLE
fix: hide private keys in swapinfo cmd by default

### DIFF
--- a/cmd/boltzcli/commands.go
+++ b/cmd/boltzcli/commands.go
@@ -285,6 +285,11 @@ var jsonFlag = &cli.BoolFlag{
 	Usage: "Prints the output as JSON",
 }
 
+var showPrivateKeysFlag = &cli.BoolFlag{
+	Name:  "show-private-keys",
+	Usage: "Include swap private keys in JSON output",
+}
+
 var listSwapsCommand = &cli.Command{
 	Name:     "listswaps",
 	Category: "Infos",
@@ -431,6 +436,7 @@ var getSwapCommand = &cli.Command{
 	Usage:     "Gets all available information about a swap",
 	ArgsUsage: "id",
 	Action:    requireNArgs(1, swapInfo),
+	Flags:     []cli.Flag{showPrivateKeysFlag},
 }
 
 func swapInfo(ctx *cli.Context) error {
@@ -441,7 +447,7 @@ func swapInfo(ctx *cli.Context) error {
 		return err
 	}
 
-	printJson(swapInfo)
+	printJson(sanitizeSwapInfo(swapInfo, ctx.Bool("show-private-keys")))
 
 	return nil
 }
@@ -454,7 +460,7 @@ var swapInfoStreamCommand = &cli.Command{
 	Action: func(ctx *cli.Context) error {
 		return swapInfoStream(ctx, ctx.Args().First(), ctx.Bool("json"))
 	},
-	Flags: []cli.Flag{jsonFlag},
+	Flags: []cli.Flag{jsonFlag, showPrivateKeysFlag},
 }
 
 func swapInfoStream(ctx *cli.Context, id string, json bool) error {
@@ -486,7 +492,7 @@ func swapInfoStream(ctx *cli.Context, id string, json bool) error {
 		}
 
 		if json {
-			printJson(info)
+			printJson(sanitizeSwapInfo(info, ctx.Bool("show-private-keys")))
 		} else {
 			var state boltzrpc.SwapState
 			if info.Swap != nil {

--- a/cmd/boltzcli/utils.go
+++ b/cmd/boltzcli/utils.go
@@ -44,6 +44,31 @@ func printJson(resp proto.Message) {
 	fmt.Println(jsonMarshaler.Format(resp))
 }
 
+const RedactedValue = "<redacted>"
+
+func sanitizeSwapInfo(resp *boltzrpc.GetSwapInfoResponse, showPrivateKeys bool) *boltzrpc.GetSwapInfoResponse {
+	if resp == nil || showPrivateKeys {
+		return resp
+	}
+
+	if resp.Swap != nil {
+		resp.Swap.PrivateKey = RedactedValue
+	}
+	if resp.ReverseSwap != nil {
+		resp.ReverseSwap.PrivateKey = RedactedValue
+	}
+	if resp.ChainSwap != nil {
+		if resp.ChainSwap.FromData != nil {
+			resp.ChainSwap.FromData.PrivateKey = RedactedValue
+		}
+		if resp.ChainSwap.ToData != nil {
+			resp.ChainSwap.ToData.PrivateKey = RedactedValue
+		}
+	}
+
+	return resp
+}
+
 func liquidAccountType(accountType string) string {
 	switch accountType {
 	case "p2sh-p2wpkh":

--- a/cmd/boltzcli/utils_test.go
+++ b/cmd/boltzcli/utils_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/BoltzExchange/boltz-client/v2/pkg/boltzrpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeSwapInfo(t *testing.T) {
+	resp := &boltzrpc.GetSwapInfoResponse{
+		Swap: &boltzrpc.SwapInfo{
+			PrivateKey: "swap-private-key",
+		},
+		ReverseSwap: &boltzrpc.ReverseSwapInfo{
+			PrivateKey: "reverse-private-key",
+		},
+		ChainSwap: &boltzrpc.ChainSwapInfo{
+			FromData: &boltzrpc.ChainSwapData{
+				PrivateKey: "from-private-key",
+			},
+			ToData: &boltzrpc.ChainSwapData{
+				PrivateKey: "to-private-key",
+			},
+		},
+	}
+
+	sanitized := sanitizeSwapInfo(resp, true)
+	require.Same(t, resp, sanitized)
+
+	sanitized = sanitizeSwapInfo(resp, false)
+
+	require.Equal(t, RedactedValue, sanitized.Swap.PrivateKey)
+	require.Equal(t, RedactedValue, sanitized.ReverseSwap.PrivateKey)
+	require.Equal(t, RedactedValue, sanitized.ChainSwap.FromData.PrivateKey)
+	require.Equal(t, RedactedValue, sanitized.ChainSwap.ToData.PrivateKey)
+}


### PR DESCRIPTION
closes: https://github.com/BoltzExchange/boltz-client/issues/644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced `--show-private-keys` flag to swap-related commands, allowing control over whether private keys are included in JSON output format. When the flag is not set, private keys are automatically redacted from all responses.

* **Tests**
  - Added comprehensive test coverage validating private key redaction functionality across various swap types and flag configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->