### PR TITLE
refactor: wallet unique constrant

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -223,7 +223,7 @@ CREATE TABLE wallets
     lastIndex      INT,
 
     UNIQUE (name, tenantId, nodePubkey),
-    UNIQUE (xpub, coreDescriptor, mnemonic, nodePubkey)
+    UNIQUE (tenantId, xpub, coreDescriptor, mnemonic, nodePubkey)
 );
 CREATE TABLE tenants
 (

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -643,7 +643,7 @@ func (database *Database) performMigration(tx *Transaction, oldVersion int) erro
 			mnemonic       VARCHAR,
 			subaccount     INT,
 			salt           VARCHAR,
-			tenantId       INT REFERENCES tenants (id),
+			tenantId       INT NOT NULL REFERENCES tenants (id),
 			legacy         BOOLEAN DEFAULT FALSE,
 			lastIndex      INT,
 

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -632,8 +632,7 @@ func (database *Database) performMigration(tx *Transaction, oldVersion int) erro
 		logMigration(oldVersion)
 
 		migration := `
-		ALTER TABLE wallets RENAME TO old_wallets;
-		CREATE TABLE wallets
+		CREATE TABLE new_wallets
 		(
 			id             INTEGER PRIMARY KEY AUTOINCREMENT,
 			name           VARCHAR,
@@ -651,9 +650,10 @@ func (database *Database) performMigration(tx *Transaction, oldVersion int) erro
 			UNIQUE (name, tenantId, nodePubkey),
 			UNIQUE (tenantId, xpub, coreDescriptor, mnemonic, nodePubkey)
 		);
-		INSERT INTO wallets (id, name, currency, nodePubkey, xpub, coreDescriptor, mnemonic, subaccount, salt, tenantId, legacy, lastIndex)
-		SELECT id, name, currency, nodePubkey, xpub, coreDescriptor, mnemonic, subaccount, salt, tenantId, legacy, lastIndex FROM old_wallets;
-		DROP TABLE old_wallets;
+		INSERT INTO new_wallets (id, name, currency, nodePubkey, xpub, coreDescriptor, mnemonic, subaccount, salt, tenantId, legacy, lastIndex)
+		SELECT id, name, currency, nodePubkey, xpub, coreDescriptor, mnemonic, subaccount, salt, tenantId, legacy, lastIndex FROM wallets;
+		DROP TABLE wallets;
+		ALTER TABLE new_wallets RENAME TO wallets;
 		`
 		if _, err := tx.Exec(migration); err != nil {
 			return err

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -21,7 +21,7 @@ type swapStatus struct {
 	status string
 }
 
-const latestSchemaVersion = 18
+const latestSchemaVersion = 19
 
 func (database *Database) migrate() error {
 	version, err := database.queryVersion()
@@ -417,7 +417,7 @@ func (database *Database) performMigration(tx *Transaction, oldVersion int) erro
 			tenantId       INT REFERENCES tenants (id),
 
 			UNIQUE (name, tenantId, nodePubkey),
-			UNIQUE (xpub, coreDescriptor, mnemonic, nodePubkey)
+			UNIQUE (tenantId, xpub, coreDescriptor, mnemonic, nodePubkey)
 		);
 		INSERT INTO wallets (name, currency, xpub, coreDescriptor, mnemonic, subaccount, salt)
 		SELECT name, currency,  xpub, coreDescriptor, mnemonic, subaccount, salt FROM old_wallets;
@@ -624,6 +624,36 @@ func (database *Database) performMigration(tx *Transaction, oldVersion int) erro
 
 		migration := `
 		UPDATE wallets SET legacy = TRUE WHERE currency = 'BTC';
+		`
+		if _, err := tx.Exec(migration); err != nil {
+			return err
+		}
+	case 18:
+		logMigration(oldVersion)
+
+		migration := `
+		ALTER TABLE wallets RENAME TO old_wallets;
+		CREATE TABLE wallets
+		(
+			id             INTEGER PRIMARY KEY AUTOINCREMENT,
+			name           VARCHAR,
+			currency       VARCHAR,
+			nodePubkey     VARCHAR,
+			xpub           VARCHAR,
+			coreDescriptor VARCHAR,
+			mnemonic       VARCHAR,
+			subaccount     INT,
+			salt           VARCHAR,
+			tenantId       INT REFERENCES tenants (id),
+			legacy         BOOLEAN DEFAULT FALSE,
+			lastIndex      INT,
+
+			UNIQUE (name, tenantId, nodePubkey),
+			UNIQUE (tenantId, xpub, coreDescriptor, mnemonic, nodePubkey)
+		);
+		INSERT INTO wallets (id, name, currency, nodePubkey, xpub, coreDescriptor, mnemonic, subaccount, salt, tenantId, legacy, lastIndex)
+		SELECT id, name, currency, nodePubkey, xpub, coreDescriptor, mnemonic, subaccount, salt, tenantId, legacy, lastIndex FROM old_wallets;
+		DROP TABLE old_wallets;
 		`
 		if _, err := tx.Exec(migration); err != nil {
 			return err

--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -1498,7 +1498,11 @@ func (server *routedBoltzServer) importWallet(ctx context.Context, credentials *
 		if existing.Name == credentials.Name && existing.TenantId == credentials.TenantId {
 			return status.Errorf(codes.InvalidArgument, "wallet %s already exists", existing.Name)
 		}
-		if existing.Currency == credentials.Currency && existing.Mnemonic == credentials.Mnemonic && existing.Xpub == credentials.Xpub && existing.CoreDescriptor == credentials.CoreDescriptor {
+		if existing.TenantId == credentials.TenantId &&
+			existing.Currency == credentials.Currency &&
+			existing.Mnemonic == credentials.Mnemonic &&
+			existing.Xpub == credentials.Xpub &&
+			existing.CoreDescriptor == credentials.CoreDescriptor {
 			return status.Errorf(codes.InvalidArgument, "wallet %s has the same credentials", existing.Name)
 		}
 	}

--- a/internal/rpcserver/wallet_test.go
+++ b/internal/rpcserver/wallet_test.go
@@ -20,7 +20,9 @@ import (
 
 	"github.com/BoltzExchange/boltz-client/v2/pkg/boltz"
 	"github.com/BoltzExchange/boltz-client/v2/pkg/boltzrpc"
+	boltzrpcclient "github.com/BoltzExchange/boltz-client/v2/pkg/boltzrpc/client"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 func TestWalletTransactions(t *testing.T) {
@@ -636,21 +638,31 @@ func TestWalletSendReceive(t *testing.T) {
 }
 
 func TestImportDuplicateCredentials(t *testing.T) {
-	client, _, stop := setup(t, setupOptions{})
+	cfg := loadConfig(t)
+	chain := getOnchain(t, cfg)
+	client, _, stop := setup(t, setupOptions{cfg: cfg, chain: chain, node: "standalone"})
 	defer stop()
 
 	testWallet := fundedWallet(t, client, boltzrpc.Currency_LBTC)
 	credentials, err := client.GetWalletCredentials(testWallet.Id, nil)
 	require.NoError(t, err)
 
-	// duplicates are only allowed for different currencies
-	second := &boltzrpc.WalletParams{Name: "another", Currency: boltzrpc.Currency_LBTC}
-	_, err = client.ImportWallet(second, credentials)
-	require.Error(t, err)
+	_, err = client.ImportWallet(&boltzrpc.WalletParams{Name: "another", Currency: boltzrpc.Currency_LBTC}, credentials)
+	requireCode(t, err, codes.InvalidArgument)
+	require.ErrorContains(t, err, "same credentials")
 
-	second.Currency = boltzrpc.Currency_BTC
+	_, write, _ := createTenant(t, client, "wallet-duplicate-tenant")
+	tenantClient := boltzrpcclient.NewBoltzClient(write)
+
+	_, err = tenantClient.ImportWallet(&boltzrpc.WalletParams{Name: "another", Currency: boltzrpc.Currency_LBTC}, credentials)
+	require.NoError(t, err)
+
+	_, err = tenantClient.ImportWallet(&boltzrpc.WalletParams{Name: "duplicate", Currency: boltzrpc.Currency_LBTC}, credentials)
+	requireCode(t, err, codes.InvalidArgument)
+	require.ErrorContains(t, err, "same credentials")
+
 	credentials.CoreDescriptor = nil
-	_, err = client.ImportWallet(second, credentials)
+	_, err = tenantClient.ImportWallet(&boltzrpc.WalletParams{Name: "another-btc", Currency: boltzrpc.Currency_BTC}, credentials)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
only enforce same wallets within tenants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wallet credentials are now scoped per tenant, allowing the same credentials to be imported for different tenants without conflicts.
* **Bug Fixes**
  * Re-import of identical credentials is rejected only when they belong to the same tenant.
* **Chores**
  * Database migration added to apply tenant-scoped wallet uniqueness.
* **Tests**
  * Import tests updated to validate tenant-scoped duplicate-credential behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->