### PR TITLE
refactor: use disable signers rpc in integration tests

### DIFF
--- a/internal/rpcserver/chain_swap_test.go
+++ b/internal/rpcserver/chain_swap_test.go
@@ -20,7 +20,6 @@ import (
 func TestChainSwap(t *testing.T) {
 	cfg := loadConfig(t)
 	chain := getOnchain(t, cfg)
-	boltzApi := getBoltz(t, cfg)
 
 	checkSwap := func(t *testing.T, client client.Boltz, id string) {
 		response, err := client.ListSwaps(&boltzrpc.ListSwapsRequest{})
@@ -45,7 +44,7 @@ func TestChainSwap(t *testing.T) {
 		require.Fail(t, "swap not returned by listswaps", id)
 	}
 
-	client, _, stop := setup(t, setupOptions{cfg: cfg, chain: chain, boltzApi: boltzApi, node: "standalone"})
+	client, _, stop := setup(t, setupOptions{cfg: cfg, chain: chain, node: "standalone"})
 	defer stop()
 
 	tests := []struct {
@@ -352,7 +351,7 @@ func TestChainSwap(t *testing.T) {
 				}
 
 				t.Run("Script", func(t *testing.T) {
-					boltzApi.DisablePartialSignatures = true
+					disableBackendSigner(t, "chain-refund-coop")
 
 					stream, statusStream := createFailed(t, refundAddress)
 					info := statusStream(boltzrpc.SwapState_ERROR, boltz.TransactionLockupFailed).ChainSwap
@@ -368,8 +367,6 @@ func TestChainSwap(t *testing.T) {
 				})
 
 				t.Run("Cooperative", func(t *testing.T) {
-					boltzApi.DisablePartialSignatures = false
-
 					_, statusStream := createFailed(t, refundAddress)
 					info := statusStream(boltzrpc.SwapState_REFUNDED, boltz.TransactionLockupFailed).ChainSwap
 					require.Zero(t, info.ServiceFee)

--- a/internal/rpcserver/helpers_test.go
+++ b/internal/rpcserver/helpers_test.go
@@ -140,6 +140,15 @@ func getTransactionFee(t *testing.T, chain *onchain.Onchain, currency boltz.Curr
 	return fee
 }
 
+func disableBackendSigner(t *testing.T, signer string) {
+	t.Helper()
+
+	test.BackendCli(fmt.Sprintf("signer disable %s", signer))
+	t.Cleanup(func() {
+		test.BackendCli(fmt.Sprintf("signer enable %s", signer))
+	})
+}
+
 var password = "password"
 var swapAmount = uint64(100000)
 

--- a/internal/rpcserver/swap_test.go
+++ b/internal/rpcserver/swap_test.go
@@ -391,13 +391,12 @@ func TestSwap(t *testing.T) {
 			for _, tc := range tests {
 				t.Run(tc.desc, func(t *testing.T) {
 					cfg := loadConfig(t)
-					boltzApi := getBoltz(t, cfg)
 					cfg.Node = "LND"
 					pair := &boltzrpc.Pair{
 						From: tc.from,
 						To:   boltzrpc.Currency_BTC,
 					}
-					admin, _, stop := setup(t, setupOptions{cfg: cfg, boltzApi: boltzApi})
+					admin, _, stop := setup(t, setupOptions{cfg: cfg})
 					defer stop()
 					fundedWallet(t, admin, tc.from)
 
@@ -481,10 +480,7 @@ func TestSwap(t *testing.T) {
 						})
 
 						t.Run("Script", func(t *testing.T) {
-							boltzApi.DisablePartialSignatures = true
-							t.Cleanup(func() {
-								boltzApi.DisablePartialSignatures = false
-							})
+							disableBackendSigner(t, "submarine-refund-coop")
 
 							refundAddress := cli("getnewaddress")
 							withStream, _ := createFailed(t, refundAddress)

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -176,7 +176,7 @@ func GetCli(pair boltz.Currency) Cli {
 }
 
 func BackendCli(cmd string) string {
-	return bash("docker exec -i boltz-backend /boltz-backend/bin/boltz-cli " + cmd)
+	return bash("docker exec -i boltz-backend /boltz-backend/target/release/boltzr-cli --grpc-certificates /boltz-data/certificates " + cmd)
 }
 
 func LiquidCli(cmd string) string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test initialization and backend behavior control for swap and chain swap scenarios.
  * Added helper function to manage backend signer configuration during testing.

* **Chores**
  * Updated backend CLI invocation and configuration for improved compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-client/pull/683)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->