### PR TITLE
fix: clamp underflow in CheckAmounts

### DIFF
--- a/pkg/boltz/fees.go
+++ b/pkg/boltz/fees.go
@@ -73,14 +73,26 @@ func RequiredEstimations(swapType SwapType, pair Pair) []Currency {
 	return currencies
 }
 
-func CheckAmounts(swapType SwapType, pair Pair, sendAmount uint64, receiveAmount uint64, serviceFee Percentage, estimations FeeEstimations, includeClaim bool) error {
-	totalFees := sendAmount - receiveAmount
-	networkFees := totalFees
-	if swapType == NormalSwap {
-		networkFees -= CalculatePercentage(serviceFee, receiveAmount)
-	} else {
-		networkFees -= CalculatePercentage(serviceFee, sendAmount)
+// saturatingSub returns a - b, or 0 if b > a, avoiding uint64 wrap-around.
+func saturatingSub(a, b uint64) uint64 {
+	if b > a {
+		return 0
 	}
+	return a - b
+}
+
+func CheckAmounts(swapType SwapType, pair Pair, sendAmount uint64, receiveAmount uint64, serviceFee Percentage, estimations FeeEstimations, includeClaim bool) error {
+	var serviceFeeAmount uint64
+	if swapType == NormalSwap {
+		serviceFeeAmount = CalculatePercentage(serviceFee, receiveAmount)
+	} else {
+		serviceFeeAmount = CalculatePercentage(serviceFee, sendAmount)
+	}
+	// If boltz quoted favorably (sendAmount < receiveAmount + serviceFeeAmount),
+	// the implied network fee is non-positive; clamp to 0 so checkTolerance reads
+	// it as no overage rather than a uint64 wrap close to 2^64.
+	networkFees := saturatingSub(saturatingSub(sendAmount, receiveAmount), serviceFeeAmount)
+
 	currencies := RequiredEstimations(swapType, pair)
 	for _, currency := range currencies {
 		if _, ok := estimations[currency]; !ok {

--- a/pkg/boltz/fees_test.go
+++ b/pkg/boltz/fees_test.go
@@ -110,6 +110,58 @@ func TestCheckFees(t *testing.T) {
 	}
 }
 
+func TestCheckAmounts_FavorableQuote(t *testing.T) {
+	// Regression: before saturatingSub, an ExpectedAmount smaller than
+	// invoiceAmount + serviceFee%·invoiceAmount caused networkFees to wrap
+	// around uint64, producing a spurious "onchain fee way above expectation"
+	// error and orphaning the swap on the boltz server.
+	feeEstimations := FeeEstimations{
+		CurrencyBtc:    2,
+		CurrencyLiquid: 0.11,
+	}
+	tests := []struct {
+		name          string
+		swapType      SwapType
+		pair          Pair
+		sendAmount    uint64
+		receiveAmount uint64
+		serviceFee    Percentage
+	}{
+		{
+			// 25M-sat BTC submarine, 0.1% fee, 10k-sat under-quote (matches
+			// the reported production incident).
+			name:          "Submarine/Btc/UnderQuoteWithinServiceFee",
+			swapType:      NormalSwap,
+			pair:          Pair{From: CurrencyBtc, To: CurrencyBtc},
+			sendAmount:    25_015_000,
+			receiveAmount: 25_000_000,
+			serviceFee:    0.1,
+		},
+		{
+			// sendAmount < receiveAmount entirely — first subtraction would wrap.
+			name:          "Submarine/Btc/SendBelowReceive",
+			swapType:      NormalSwap,
+			pair:          Pair{From: CurrencyBtc, To: CurrencyBtc},
+			sendAmount:    49_999,
+			receiveAmount: 50_000,
+			serviceFee:    0.5,
+		},
+		{
+			name:          "Reverse/Btc/UnderQuoteWithinServiceFee",
+			swapType:      ReverseSwap,
+			pair:          Pair{From: CurrencyBtc, To: CurrencyBtc},
+			sendAmount:    50_000,
+			receiveAmount: 49_900,
+			serviceFee:    0.5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, CheckAmounts(tt.swapType, tt.pair, tt.sendAmount, tt.receiveAmount, tt.serviceFee, feeEstimations, true))
+		})
+	}
+}
+
 func Test_checkTolerance(t *testing.T) {
 	type args struct {
 		expected uint64


### PR DESCRIPTION
The two uint64 subtractions in CheckAmounts wrapped around 2^64 whenever boltz returned an ExpectedAmount smaller than invoiceAmount + service fee, producing a spurious "onchain fee way above expectation: 1844..." error. The swap was already created on the boltz server at that point but the DB row was never written, orphaning it.

Use a saturatingSub helper so a favorable quote yields networkFees=0 and checkTolerance reads it as no overage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fee-calculation edge case that could produce incorrect (wrapped or negative) network fee values for favorable or under-quoted amounts, improving swap fee accuracy and preventing erroneous rejections.

* **Tests**
  * Added regression tests covering favorable/under-quoted scenarios to ensure fee calculations remain correct across swap types and network conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoltzExchange/boltz-client/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->