### PR TITLE
fix: multi chain broadcast race

### DIFF
--- a/internal/onchain/multi_chain.go
+++ b/internal/onchain/multi_chain.go
@@ -37,36 +37,36 @@ func (m MultiChainProvider) GetRawTransaction(txId string) (hex string, err erro
 	return "", err
 }
 
-func (m MultiChainProvider) BroadcastTransaction(txHex string) (txId string, err error) {
+func (m MultiChainProvider) BroadcastTransaction(txHex string) (string, error) {
 	providers := m.allProviders()
-	resultChan := make(chan string)
-	errChan := make(chan error, len(providers))
+	type broadcastResult struct {
+		txId string
+		err  error
+	}
+	// Buffered so every goroutine can deliver its result even after we
+	// return early, guaranteeing the loop below receives exactly one
+	// message per provider.
+	results := make(chan broadcastResult, len(providers))
 
 	// Broadcasting transactions via all known (including boltz) providers is fine
 	for _, provider := range providers {
 		provider := provider
 		go func() {
-			result, err := provider.BroadcastTransaction(txHex)
-			if err == nil {
-				select {
-				case resultChan <- result:
-				default:
-				}
-			} else {
+			txId, err := provider.BroadcastTransaction(txHex)
+			if err != nil {
 				logger.Debugf("Error broadcasting transaction via %s: %v", provider, err)
-				errChan <- err
 			}
+			results <- broadcastResult{txId: txId, err: err}
 		}()
 	}
 
 	var merr multierror.Error
 	for range providers {
-		select {
-		case txId = <-resultChan:
-			return txId, nil
-		case err := <-errChan:
-			merr.Errors = append(merr.Errors, err)
+		result := <-results
+		if result.err == nil {
+			return result.txId, nil
 		}
+		merr.Errors = append(merr.Errors, result.err)
 	}
 	return "", &merr
 }

--- a/internal/rpcserver/server.go
+++ b/internal/rpcserver/server.go
@@ -404,7 +404,11 @@ func initBoltz(cfg *config.Config, network *boltz.Network) (*boltz.Api, error) {
 		logger.Info("Using configured Boltz endpoint: " + boltzUrl)
 	}
 
-	boltzApi := &boltz.Api{URL: boltzUrl, Referral: cfg.ReferralId}
+	boltzApi := &boltz.Api{
+		URL:      boltzUrl,
+		Referral: cfg.ReferralId,
+		Client:   http.Client{Timeout: 30 * time.Second},
+	}
 	if cfg.Proxy != "" {
 		proxy, err := url.Parse(cfg.Proxy)
 		if err != nil {
@@ -412,10 +416,7 @@ func initBoltz(cfg *config.Config, network *boltz.Network) (*boltz.Api, error) {
 		}
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.Proxy = http.ProxyURL(proxy)
-		boltzApi.Client = http.Client{
-			Transport: transport,
-			Timeout:   30 * time.Second,
-		}
+		boltzApi.Client.Transport = transport
 	}
 
 	return boltzApi, nil


### PR DESCRIPTION
if two providers return simultaneously where the first one errors and
the second one doesn't the result of the second one can get dismissed if
there is no listener on the `resultChan` at that exact moment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transaction broadcast mechanism redesigned to reliably deliver results across multiple blockchain providers concurrently, ensuring no data loss and enabling immediate return upon first successful broadcast
  * HTTP API client initialization enhanced with explicit timeout configuration and improved proxy URL handling for better connection stability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->