### PR TITLE
chore: move release workflow back to github runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Build binaries
 
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION
self hosted runner isnt needed now anymore since the workflow runs much
faster
