### PR TITLE
feat: exclude permant errors from automatic retry

### DIFF
--- a/internal/database/chain.go
+++ b/internal/database/chain.go
@@ -330,6 +330,7 @@ WHERE data.lockupTransactionId != ''
 func (database *Database) QueryClaimableChainSwaps(tenantId *Id, currency boltz.Currency) ([]*ChainSwap, error) {
 	query := claimableChainSwapsQuery
 	values := []any{currency, boltzrpc.SwapState_REFUNDED}
+	query, values = excludePermanentErrors("swaps.error", query, values)
 	if tenantId != nil {
 		query += " AND tenantId = ?"
 		values = append(values, tenantId)

--- a/internal/database/claimable_test.go
+++ b/internal/database/claimable_test.go
@@ -1,0 +1,65 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/BoltzExchange/boltz-client/v2/internal/database"
+	"github.com/BoltzExchange/boltz-client/v2/internal/test"
+	"github.com/BoltzExchange/boltz-client/v2/pkg/boltz"
+	"github.com/BoltzExchange/boltz-client/v2/pkg/boltzrpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryClaimableSwapsExcludesPermanentErrors(t *testing.T) {
+	db := database.Database{Path: "file:claimable_test?mode=memory&cache=shared"}
+	require.NoError(t, db.Connect())
+
+	reverse := func(id, swapErr string) database.ReverseSwap {
+		return database.ReverseSwap{
+			Id:                  id,
+			Pair:                boltz.Pair{From: boltz.CurrencyLiquid, To: boltz.CurrencyBtc},
+			Status:              boltz.TransactionMempool,
+			LockupTransactionId: "lockup",
+			Error:               swapErr,
+		}
+	}
+	chain := func(id, swapErr string) database.ChainSwap {
+		return database.ChainSwap{
+			Id:     id,
+			State:  boltzrpc.SwapState_PENDING,
+			Status: boltz.TransactionMempool,
+			Error:  swapErr,
+			ToData: &database.ChainSwapData{LockupTransactionId: "lockup"},
+		}
+	}
+
+	test.FakeSwaps{
+		ReverseSwaps: []database.ReverseSwap{
+			reverse("rev-no-error", ""),
+			reverse("rev-transient", "broadcast: some transient error"),
+			reverse("rev-permanent", "broadcast: bad-txns-inputs-missingorspent"),
+			// upper-case to assert case-insensitive matching (was strings.ToLower before)
+			reverse("rev-permanent-upper", "BROADCAST: TXN-MEMPOOL-CONFLICT"),
+		},
+		ChainSwaps: []database.ChainSwap{
+			chain("chain-no-error", ""),
+			chain("chain-permanent", "broadcast: bad-txns-inputs-missing-or-spent"),
+		},
+	}.Create(t, &db)
+
+	reverseSwaps, err := db.QueryClaimableReverseSwaps(nil, boltz.CurrencyBtc)
+	require.NoError(t, err)
+	var reverseIds []string
+	for _, swap := range reverseSwaps {
+		reverseIds = append(reverseIds, swap.Id)
+	}
+	require.ElementsMatch(t, []string{"rev-no-error", "rev-transient"}, reverseIds)
+
+	chainSwaps, err := db.QueryClaimableChainSwaps(nil, boltz.CurrencyBtc)
+	require.NoError(t, err)
+	var chainIds []string
+	for _, swap := range chainSwaps {
+		chainIds = append(chainIds, swap.Id)
+	}
+	require.ElementsMatch(t, []string{"chain-no-error"}, chainIds)
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -345,6 +345,7 @@ type SwapQuery struct {
 	TenantId *Id
 	Limit    *uint64
 	Offset   *uint64
+	Ids      []string
 }
 
 var PendingSwapQuery = SwapQuery{
@@ -387,6 +388,14 @@ func (query *SwapQuery) ToWhereClauseWithExisting(conditions []string, values []
 	if query.TenantId != nil {
 		conditions = append(conditions, "tenantId = ?")
 		values = append(values, query.TenantId)
+	}
+	if len(query.Ids) > 0 {
+		placeholders := make([]string, len(query.Ids))
+		for i, id := range query.Ids {
+			placeholders[i] = "?"
+			values = append(values, id)
+		}
+		conditions = append(conditions, "id IN ("+strings.Join(placeholders, ",")+")")
 	}
 	var where string
 	if len(conditions) > 0 {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -408,6 +408,24 @@ func (query *SwapQuery) ToWhereClause() (string, []any) {
 	return query.ToWhereClauseWithExisting([]string{}, []any{})
 }
 
+// permanentClaimErrors are error substrings that mean a swap can never be claimed
+// (e.g. the lockup inputs are missing or already spent). Swaps whose stored error
+// contains one of these are excluded from the claimable queries so they are not
+// retried automatically nor offered for manual claiming.
+var permanentClaimErrors = []string{
+	"bad-txns-inputs-missingorspent",
+	"bad-txns-inputs-missing-or-spent",
+	"txn-mempool-conflict",
+}
+
+func excludePermanentErrors(errorColumn, query string, values []any) (string, []any) {
+	for _, permanentErr := range permanentClaimErrors {
+		query += fmt.Sprintf(" AND (%s IS NULL OR %s NOT LIKE ?)", errorColumn, errorColumn)
+		values = append(values, "%"+permanentErr+"%")
+	}
+	return query, values
+}
+
 func (database *Database) Connect() error {
 	if database.db == nil {
 		logger.Info("Opening database: " + database.Path)

--- a/internal/database/reverse.go
+++ b/internal/database/reverse.go
@@ -277,6 +277,7 @@ WHERE toCurrency = ?
 func (database *Database) QueryClaimableReverseSwaps(tenantId *Id, currency boltz.Currency) ([]*ReverseSwap, error) {
 	query := claimableSwapsQuery
 	values := []any{currency, boltz.TransactionRefunded.String()}
+	query, values = excludePermanentErrors("reverseSwaps.error", query, values)
 	if tenantId != nil {
 		query += " AND tenantId = ?"
 		values = append(values, *tenantId)

--- a/internal/database/reverse.go
+++ b/internal/database/reverse.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"time"
 
@@ -237,7 +236,7 @@ func (database *Database) QueryReverseSwap(id string) (reverseSwap *ReverseSwap,
 			return reverseSwap, err
 		}
 	} else {
-		return reverseSwap, errors.New("could not find Reverse Swap " + id)
+		return reverseSwap, sql.ErrNoRows
 	}
 
 	return reverseSwap, err

--- a/internal/nursery/listener.go
+++ b/internal/nursery/listener.go
@@ -2,6 +2,8 @@ package nursery
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/BoltzExchange/boltz-client/v2/internal/database"
 	"github.com/BoltzExchange/boltz-client/v2/internal/logger"
@@ -19,6 +21,12 @@ func (nursery *Nursery) checkClaimableSwaps(currency boltz.Currency) error {
 	if err != nil {
 		return fmt.Errorf("could not query claimable Swaps: %w", err)
 	}
+	reverseSwaps = slices.DeleteFunc(reverseSwaps, func(swap *database.ReverseSwap) bool {
+		return !shouldClaimAutomatically(boltz.ReverseSwap, swap.Id, swap.Error)
+	})
+	chainSwaps = slices.DeleteFunc(chainSwaps, func(swap *database.ChainSwap) bool {
+		return !shouldClaimAutomatically(boltz.ChainSwap, swap.Id, swap.Error)
+	})
 	if len(reverseSwaps) > 0 || len(chainSwaps) > 0 {
 		logger.Infof("Found %d claimable Swaps", len(reverseSwaps)+len(chainSwaps))
 		if _, err := nursery.claimSwaps(currency, reverseSwaps, chainSwaps); err != nil {
@@ -26,6 +34,23 @@ func (nursery *Nursery) checkClaimableSwaps(currency boltz.Currency) error {
 		}
 	}
 	return nil
+}
+
+var permanentClaimErrors = []string{
+	"bad-txns-inputs-missingorspent",
+	"bad-txns-inputs-missing-or-spent",
+	"txn-mempool-conflict",
+}
+
+func shouldClaimAutomatically(swapType boltz.SwapType, swapId string, err string) bool {
+	lowerErr := strings.ToLower(err)
+	for _, permanentErr := range permanentClaimErrors {
+		if strings.Contains(lowerErr, permanentErr) {
+			logger.Debugf("Skipping automatic claim for %s Swap %s after permanent error: %s", swapType, swapId, err)
+			return false
+		}
+	}
+	return true
 }
 
 func (nursery *Nursery) startBlockListener(currency boltz.Currency) *utils.ChannelForwarder[*onchain.BlockEpoch] {

--- a/internal/nursery/listener.go
+++ b/internal/nursery/listener.go
@@ -2,8 +2,6 @@ package nursery
 
 import (
 	"fmt"
-	"slices"
-	"strings"
 
 	"github.com/BoltzExchange/boltz-client/v2/internal/database"
 	"github.com/BoltzExchange/boltz-client/v2/internal/logger"
@@ -21,12 +19,6 @@ func (nursery *Nursery) checkClaimableSwaps(currency boltz.Currency) error {
 	if err != nil {
 		return fmt.Errorf("could not query claimable Swaps: %w", err)
 	}
-	reverseSwaps = slices.DeleteFunc(reverseSwaps, func(swap *database.ReverseSwap) bool {
-		return !shouldClaimAutomatically(boltz.ReverseSwap, swap.Id, swap.Error)
-	})
-	chainSwaps = slices.DeleteFunc(chainSwaps, func(swap *database.ChainSwap) bool {
-		return !shouldClaimAutomatically(boltz.ChainSwap, swap.Id, swap.Error)
-	})
 	if len(reverseSwaps) > 0 || len(chainSwaps) > 0 {
 		logger.Infof("Found %d claimable Swaps", len(reverseSwaps)+len(chainSwaps))
 		if _, err := nursery.claimSwaps(currency, reverseSwaps, chainSwaps); err != nil {
@@ -34,23 +26,6 @@ func (nursery *Nursery) checkClaimableSwaps(currency boltz.Currency) error {
 		}
 	}
 	return nil
-}
-
-var permanentClaimErrors = []string{
-	"bad-txns-inputs-missingorspent",
-	"bad-txns-inputs-missing-or-spent",
-	"txn-mempool-conflict",
-}
-
-func shouldClaimAutomatically(swapType boltz.SwapType, swapId string, err string) bool {
-	lowerErr := strings.ToLower(err)
-	for _, permanentErr := range permanentClaimErrors {
-		if strings.Contains(lowerErr, permanentErr) {
-			logger.Debugf("Skipping automatic claim for %s Swap %s after permanent error: %s", swapType, swapId, err)
-			return false
-		}
-	}
-	return true
 }
 
 func (nursery *Nursery) startBlockListener(currency boltz.Currency) *utils.ChannelForwarder[*onchain.BlockEpoch] {

--- a/internal/rpcserver/chain_swap_test.go
+++ b/internal/rpcserver/chain_swap_test.go
@@ -538,8 +538,9 @@ func TestChainSwap(t *testing.T) {
 							checkTxOutAddress(t, chain, parseCurrency(pair.To), response.TransactionId, toAddress, true)
 							checkSwap(t, client, info.Id)
 
+							// claiming again should re-broadcast without error
 							_, err = client.ClaimSwaps(request)
-							requireCode(t, err, codes.NotFound)
+							require.NoError(t, err)
 						})
 					})
 					t.Run("Wallet", func(t *testing.T) {
@@ -570,9 +571,18 @@ func TestChainSwap(t *testing.T) {
 								return fromWallet.Balance.Unconfirmed > 0
 							}, 10*time.Second, 250*time.Millisecond)
 
+							// claiming again should re-broadcast without error
 							_, err = client.ClaimSwaps(request)
-							requireCode(t, err, codes.NotFound)
+							require.NoError(t, err)
 						})
+					})
+					t.Run("Tenant", func(t *testing.T) {
+						info, _, _ := createClaimable(t)
+
+						// the swap belongs to the admin tenant, so another tenant must not be able to claim it
+						tenant := tenantClient(t, client, "claim-tenant")
+						_, err := tenant.ClaimSwaps(&boltzrpc.ClaimSwapsRequest{SwapIds: []string{info.Id}})
+						requireCode(t, err, codes.NotFound)
 					})
 				})
 			}

--- a/internal/rpcserver/helpers_test.go
+++ b/internal/rpcserver/helpers_test.go
@@ -42,6 +42,11 @@ func requireCode(t *testing.T, err error, code codes.Code) {
 	assert.Equal(t, code, status.Code(err))
 }
 
+func tenantClient(t *testing.T, admin client.Boltz, name string) client.Boltz {
+	_, write, _ := createTenant(t, admin, name)
+	return client.NewBoltzClient(write)
+}
+
 func loadConfig(t *testing.T) *config.Config {
 	dataDir := "test"
 	cfg, err := config.LoadConfig(dataDir)

--- a/internal/rpcserver/reverse_swap_test.go
+++ b/internal/rpcserver/reverse_swap_test.go
@@ -5,6 +5,8 @@ package rpcserver
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -246,6 +248,47 @@ func TestReverseSwap(t *testing.T) {
 		// new block triggers a retry, on which the broadcast will succeed
 		statusStream(boltzrpc.SwapState_SUCCESSFUL, boltz.InvoiceSettled)
 		checkSwap(t, client, swap.Id, chain)
+	})
+
+	t.Run("PermanentBroadcastErrorStopsRetry", func(t *testing.T) {
+		cfg := loadConfig(t)
+		chain := getOnchain(t, cfg)
+		client, _, stop := setup(t, setupOptions{cfg: cfg, chain: chain})
+		defer stop()
+
+		originalChain := chain.Btc.Chain
+		var broadcasts atomic.Int32
+		chainMock := onchainmock.NewMockChainProvider(t)
+		chainMock.EXPECT().BroadcastTransaction(mock.Anything).RunAndReturn(func(string) (string, error) {
+			broadcasts.Add(1)
+			return "", errors.New("bad-txns-inputs-missingorspent")
+		}).Maybe()
+		coverChainProvider(t, chainMock, originalChain)
+		chain.Btc.Chain = chainMock
+
+		swap, err := client.CreateReverseSwap(&boltzrpc.CreateReverseSwapRequest{
+			Amount:         100000,
+			AcceptZeroConf: false,
+		})
+		require.NoError(t, err)
+
+		_, statusStream := swapStream(t, client, swap.Id)
+		statusStream(boltzrpc.SwapState_PENDING, boltz.TransactionMempool)
+		test.MineBlock()
+		info := statusStream(boltzrpc.SwapState_ERROR, boltz.TransactionConfirmed)
+		require.Equal(t, "broadcast: bad-txns-inputs-missingorspent", info.ReverseSwap.Error)
+		require.Equal(t, int32(1), broadcasts.Load())
+
+		test.MineBlock()
+		require.Never(t, func() bool {
+			return broadcasts.Load() > 1
+		}, 3*time.Second, 100*time.Millisecond)
+
+		info, err = client.GetSwapInfo(swap.Id)
+		require.NoError(t, err)
+		require.Equal(t, boltzrpc.SwapState_ERROR, info.ReverseSwap.State)
+		require.Empty(t, info.ReverseSwap.ClaimTransactionId)
+		require.Equal(t, "broadcast: bad-txns-inputs-missingorspent", info.ReverseSwap.Error)
 	})
 
 	t.Run("Standalone", func(t *testing.T) {

--- a/internal/rpcserver/reverse_swap_test.go
+++ b/internal/rpcserver/reverse_swap_test.go
@@ -484,8 +484,9 @@ func TestReverseSwap(t *testing.T) {
 
 				checkTxOutAddress(t, chain, boltz.CurrencyBtc, response.TransactionId, destination.Address, true)
 
+				// claiming again should re-broadcast without error
 				_, err = client.ClaimSwaps(request)
-				requireCode(t, err, codes.NotFound)
+				require.NoError(t, err)
 			})
 		})
 		t.Run("Wallet", func(t *testing.T) {
@@ -511,9 +512,18 @@ func TestReverseSwap(t *testing.T) {
 				require.NotEmpty(t, claimedSwap.ReverseSwap.ClaimAddress)
 				checkTxOutAddress(t, chain, boltz.CurrencyBtc, response.TransactionId, claimedSwap.ReverseSwap.ClaimAddress, true)
 
+				// claiming again should re-broadcast without error
 				_, err = client.ClaimSwaps(request)
-				requireCode(t, err, codes.NotFound)
+				require.NoError(t, err)
 			})
+		})
+		t.Run("Tenant", func(t *testing.T) {
+			info, _, _ := createClaimable(t)
+
+			// the swap belongs to the admin tenant, so another tenant must not be able to claim it
+			tenant := tenantClient(t, client, "claim-tenant")
+			_, err := tenant.ClaimSwaps(&boltzrpc.ClaimSwapsRequest{SwapIds: []string{info.Id}})
+			requireCode(t, err, codes.NotFound)
 		})
 	})
 }

--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -583,7 +583,7 @@ func (server *routedBoltzServer) ClaimSwaps(ctx context.Context, request *boltzr
 	}
 
 	if len(chainSwaps) == 0 && len(reverseSwaps) == 0 {
-		return nil, status.Errorf(codes.NotFound, "no swaps with ids %s found", request.SwapIds)
+		return nil, status.Errorf(codes.NotFound, "no swaps with ids %v found", strings.Join(request.SwapIds, ","))
 	}
 
 	for _, chainSwap := range chainSwaps {

--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -564,28 +564,39 @@ func (server *routedBoltzServer) ClaimSwaps(ctx context.Context, request *boltzr
 	var reverseSwaps []*database.ReverseSwap
 	var chainSwaps []*database.ChainSwap
 	var currency boltz.Currency
+	var err error
 
-	claimableReverseSwaps, claimableChainSwaps, err := server.queryClaimableSwaps(ctx)
+	if len(request.SwapIds) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "no swap ids provided")
+	}
+
+	tenantId := requireTenantId(ctx)
+	swapQuery := database.SwapQuery{Ids: request.SwapIds, TenantId: &tenantId}
+
+	chainSwaps, err = server.database.QueryChainSwaps(swapQuery)
+	if err != nil {
+		return nil, err
+	}
+	reverseSwaps, err = server.database.QueryReverseSwaps(swapQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, swap := range claimableReverseSwaps {
-		if slices.Contains(request.SwapIds, swap.Id) {
-			currency = swap.Pair.To
-			reverseSwaps = append(reverseSwaps, swap)
-		}
+	if len(chainSwaps) == 0 && len(reverseSwaps) == 0 {
+		return nil, status.Errorf(codes.NotFound, "no swaps with ids %s found", request.SwapIds)
 	}
 
-	for _, chainSwap := range claimableChainSwaps {
-		if slices.Contains(request.SwapIds, chainSwap.Id) {
-			currency = chainSwap.Pair.To
-			chainSwaps = append(chainSwaps, chainSwap)
+	for _, chainSwap := range chainSwaps {
+		if currency != "" && currency != chainSwap.Pair.To {
+			return nil, status.Errorf(codes.InvalidArgument, "all swaps must be the same currency")
 		}
+		currency = chainSwap.Pair.To
 	}
-
-	if len(reverseSwaps) == 0 && len(chainSwaps) == 0 {
-		return nil, status.Errorf(codes.NotFound, "no claimable swaps with ids %s found", request.SwapIds)
+	for _, reverseSwap := range reverseSwaps {
+		if currency != "" && currency != reverseSwap.Pair.To {
+			return nil, status.Errorf(codes.InvalidArgument, "all swaps must be the same currency")
+		}
+		currency = reverseSwap.Pair.To
 	}
 
 	if destination, ok := request.Destination.(*boltzrpc.ClaimSwapsRequest_Address); ok {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeat `ClaimSwaps` calls for successful manual-claims now re-broadcast successfully instead of returning “not found”.
  * Permanent broadcast errors now stop retries immediately.
  * Claimable swap lookups now exclude swaps marked with permanent errors.
  * `ClaimSwaps` now requires explicit swap IDs, returns “not found” when none match, and enforces destination-currency consistency.
* **Tests**
  * Added coverage for permanent broadcast failure stopping.
  * Added/updated tenant ownership validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->