### PR TITLE
fix: autoswap setup race

### DIFF
--- a/internal/autoswap/autoswap.go
+++ b/internal/autoswap/autoswap.go
@@ -110,13 +110,16 @@ func (autoSwap *AutoSwap) UpdateLightningConfig(request *autoswaprpc.UpdateLight
 	lnSwapper := autoSwap.lnSwapper
 	var base *SerializedLnConfig
 	if lnSwapper == nil || request.GetReset_() {
-		autoSwap.lnSwapper = &LightningSwapper{
+		if lnSwapper != nil {
+			lnSwapper.Stop()
+		}
+		lnSwapper = &LightningSwapper{
 			shared:      autoSwap.shared,
 			swapperType: Lightning,
 		}
 		base = DefaultLightningConfig()
 	} else {
-		base = autoSwap.lnSwapper.cfg.SerializedLnConfig
+		base = lnSwapper.cfg.SerializedLnConfig
 	}
 	if config == nil {
 		config = base
@@ -128,9 +131,10 @@ func (autoSwap *AutoSwap) UpdateLightningConfig(request *autoswaprpc.UpdateLight
 		config = updated.(*SerializedLnConfig)
 	}
 
-	if err := autoSwap.lnSwapper.setConfig(NewLightningConfig(config, autoSwap.shared)); err != nil {
+	if err := lnSwapper.setConfig(NewLightningConfig(config, autoSwap.shared)); err != nil {
 		return err
 	}
+	autoSwap.lnSwapper = lnSwapper
 	return autoSwap.saveConfig()
 }
 


### PR DESCRIPTION
there's a race condition, especially surfacing in tests, where the ln
swapper already runs and then tries to access its config before its
properly initialized:
https://github.com/BoltzExchange/boltz-client/actions/runs/27654951884/job/81787135403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration management for Lightning swapper initialization and updates to ensure more reliable setting application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->