### PR TITLE
fix: dont ignore last index on full scan

### DIFF
--- a/internal/onchain/liquid-wallet/wallet.go
+++ b/internal/onchain/liquid-wallet/wallet.go
@@ -321,7 +321,7 @@ type connectResult struct {
 }
 
 func (w *Wallet) Sync() error {
-	if err := w.fullScan(false); err != nil {
+	if err := w.fullScan(); err != nil {
 		return err
 	}
 	if err := w.autoConsolidate(); err != nil {
@@ -331,16 +331,10 @@ func (w *Wallet) Sync() error {
 }
 
 func (w *Wallet) FullScan() error {
-	if err := w.fullScan(true); err != nil {
-		return err
-	}
-	if err := w.autoConsolidate(); err != nil {
-		return fmt.Errorf("auto consolidation: %w", err)
-	}
-	return nil
+	return w.Sync()
 }
 
-func (w *Wallet) fullScan(all bool) error {
+func (w *Wallet) fullScan() error {
 	w.syncLock.Lock()
 	defer w.syncLock.Unlock()
 
@@ -348,7 +342,9 @@ func (w *Wallet) fullScan(all bool) error {
 	if err != nil {
 		return fmt.Errorf("load last index: %w", err)
 	}
-	if index == nil || all {
+	// FullScanToIndex treats this as a minimum and continues until its gap limit.
+	// Never lower a known index, or an internal address gap can truncate wallet history.
+	if index == nil {
 		idx := uint32(0)
 		index = &idx
 	}

--- a/internal/onchain/liquid-wallet/wallet_test.go
+++ b/internal/onchain/liquid-wallet/wallet_test.go
@@ -85,6 +85,40 @@ func TestWallet_NewAddress(t *testing.T) {
 	require.Equal(t, uint32(2), *idx)
 }
 
+func TestWallet_FullScanAddressGap(t *testing.T) {
+	const gapLimit = 20
+	amount := uint64(10000)
+
+	cfg := test.LiquidBackendConfig(t)
+	backend, err := liquid_wallet.NewBackend(cfg)
+	require.NoError(t, err)
+	wallet := newWallet(t, backend, nil)
+
+	firstAddress, err := wallet.NewAddress()
+	require.NoError(t, err)
+	test.SendToAddress(test.LiquidCli, firstAddress, amount)
+
+	// leave a full scan batch of unused addresses between funded addresses
+	var lastAddress string
+	for range gapLimit * 2 {
+		lastAddress, err = wallet.NewAddress()
+		require.NoError(t, err)
+	}
+	test.SendToAddress(test.LiquidCli, lastAddress, amount)
+	test.MineBlock()
+
+	require.Eventually(t, func() bool {
+		if err := wallet.FullScan(); err != nil {
+			return false
+		}
+		balance, err := wallet.GetBalance()
+		if err != nil {
+			return false
+		}
+		return balance.Total == 2*amount
+	}, 30*syncInterval, syncInterval)
+}
+
 func TestWallet_AutoConsolidate(t *testing.T) {
 	numTxns := 5
 	cfg := test.LiquidBackendConfig(t)


### PR DESCRIPTION
if we start off idx 0 we get issues if there was a gap in the wallet
since the sequential scans to the full index do not repair the state but
leave it broken


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet synchronization behavior to consistently resume from the last persisted scan position.
  * Updated full-scan behavior to avoid restarting scans and to continue correctly through the configured unused-address gap limit.
  * Added safe handling for first-time scans when no prior scan index exists.
* **Tests**
  * Added an integration test covering full-scan recovery across a deliberate address gap, verifying balances converge as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->