### PR TITLE
fix(lwk): dont run auto-consolidate on read-only wallets

### DIFF
--- a/internal/onchain/liquid-wallet/wallet.go
+++ b/internal/onchain/liquid-wallet/wallet.go
@@ -324,8 +324,10 @@ func (w *Wallet) Sync() error {
 	if err := w.fullScan(); err != nil {
 		return err
 	}
-	if err := w.autoConsolidate(); err != nil {
-		return fmt.Errorf("auto consolidation: %w", err)
+	if !w.info.Readonly {
+		if err := w.autoConsolidate(); err != nil {
+			return fmt.Errorf("auto consolidation: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only wallets no longer attempt automatic consolidation during synchronization, preventing unnecessary consolidation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->