### PR TITLE
refactor: remove startup full scan

### DIFF
--- a/internal/autoswap/chain_test.go
+++ b/internal/autoswap/chain_test.go
@@ -31,6 +31,7 @@ func (m mockedWallet) Create(t *testing.T) *onchainmock.MockWallet {
 	wallet.EXPECT().Ready().Return(true).Maybe()
 	wallet.EXPECT().GetWalletInfo().Return(m.info)
 	wallet.EXPECT().Sync().Return(nil).Maybe()
+	wallet.EXPECT().FullScan().Return(nil).Maybe()
 	if m.balance != nil {
 		wallet.EXPECT().GetBalance().Return(m.balance, nil)
 	}

--- a/internal/onchain/onchain.go
+++ b/internal/onchain/onchain.go
@@ -124,6 +124,9 @@ func (onchain *Onchain) startSyncLoop(wallet Wallet) {
 	onchain.syncWait.Add(1)
 	go func() {
 		defer onchain.syncWait.Done()
+		if err := wallet.FullScan(); err != nil {
+			logger.Errorf("Failed to full scan wallet %s: %v", wallet.GetWalletInfo().String(), err)
+		}
 		for {
 			currency := wallet.GetWalletInfo().Currency
 			interval, ok := onchain.WalletSyncIntervals[currency]

--- a/internal/onchain/onchain_test.go
+++ b/internal/onchain/onchain_test.go
@@ -196,6 +196,7 @@ func TestWalletSync(t *testing.T) {
 	t.Run("Remove", func(t *testing.T) {
 		onchainInstance := setup(t)
 		wallet := onchainmock.NewMockWallet(t)
+		wallet.EXPECT().FullScan().Return(nil).Maybe()
 		done := make(chan struct{})
 		wallet.EXPECT().Sync().RunAndReturn(func() error {
 			go func() {
@@ -234,6 +235,7 @@ func TestWalletSync(t *testing.T) {
 		}).Once()
 		wallet.EXPECT().Disconnect().Return(nil).NotBefore(sync).Once()
 		wallet.EXPECT().GetWalletInfo().Return(onchain.WalletInfo{Id: 1, Currency: boltz.CurrencyBtc}).Maybe()
+		wallet.EXPECT().FullScan().Return(nil).Maybe()
 		onchainInstance.AddWallet(wallet)
 
 		select {

--- a/internal/rpcserver/router.go
+++ b/internal/rpcserver/router.go
@@ -2156,9 +2156,6 @@ func (server *routedBoltzServer) unlock(password string) error {
 					logger.Errorf("Could not login to wallet %s: %v", creds.String(), err)
 				} else {
 					logger.Debugf("Logged into wallet: %s", wallet.GetWalletInfo().String())
-					if err := wallet.FullScan(); err != nil {
-						logger.Errorf("Failed to full scan wallet %s: %v", wallet.GetWalletInfo().String(), err)
-					}
 					server.onchain.AddWallet(wallet)
 				}
 			}()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallets now perform an initial synchronization when the on-chain service starts.
  * Wallet login completes without an extra blocking scan, allowing wallets to become available sooner.
  * Initial synchronization errors are logged while allowing ongoing synchronization to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->