### PR TITLE
feat: limit wallet sync concurrency via semaphore

### DIFF
--- a/internal/onchain/onchain.go
+++ b/internal/onchain/onchain.go
@@ -74,9 +74,9 @@ var DefaultWalletSyncIntervals = map[boltz.Currency]time.Duration{
 	boltz.CurrencyLiquid: time.Minute,
 }
 
-// DefaultMaxSyncConcurrency limits how many wallets sync at the same time,
+// MaxSyncConcurrency limits how many wallets sync at the same time,
 // so a large number of wallets doesn't overload a single backend.
-const DefaultMaxSyncConcurrency = 32
+const MaxSyncConcurrency = 32
 
 type Currency struct {
 	Chain       ChainProvider
@@ -91,7 +91,6 @@ type Onchain struct {
 	OnWalletChange           *utils.ChannelForwarder[[]Wallet]
 	WalletSyncIntervals      map[boltz.Currency]time.Duration
 	LiquidWalletSyncInterval uint32
-	MaxSyncConcurrency       int
 
 	syncWait      sync.WaitGroup
 	syncCtx       context.Context
@@ -116,10 +115,7 @@ func (onchain *Onchain) Init() {
 	if onchain.LiquidWalletSyncInterval != 0 {
 		onchain.WalletSyncIntervals[boltz.CurrencyLiquid] = time.Duration(onchain.LiquidWalletSyncInterval) * time.Second
 	}
-	if onchain.MaxSyncConcurrency <= 0 {
-		onchain.MaxSyncConcurrency = DefaultMaxSyncConcurrency
-	}
-	onchain.syncSemaphore = make(chan struct{}, onchain.MaxSyncConcurrency)
+	onchain.syncSemaphore = make(chan struct{}, MaxSyncConcurrency)
 }
 
 // acquireSyncSlot blocks until a sync slot is available or the sync context is

--- a/internal/onchain/onchain.go
+++ b/internal/onchain/onchain.go
@@ -74,6 +74,10 @@ var DefaultWalletSyncIntervals = map[boltz.Currency]time.Duration{
 	boltz.CurrencyLiquid: time.Minute,
 }
 
+// DefaultMaxSyncConcurrency limits how many wallets sync at the same time,
+// so a large number of wallets doesn't overload a single backend.
+const DefaultMaxSyncConcurrency = 32
+
 type Currency struct {
 	Chain       ChainProvider
 	blockHeight atomic.Uint32
@@ -87,10 +91,13 @@ type Onchain struct {
 	OnWalletChange           *utils.ChannelForwarder[[]Wallet]
 	WalletSyncIntervals      map[boltz.Currency]time.Duration
 	LiquidWalletSyncInterval uint32
+	MaxSyncConcurrency       int
 
-	syncWait   sync.WaitGroup
-	syncCtx    context.Context
-	syncCancel func()
+	syncWait      sync.WaitGroup
+	syncCtx       context.Context
+	syncCancel    func()
+	syncSemaphore chan struct{}
+	walletsLock   sync.RWMutex
 }
 
 func (onchain *Onchain) Init() {
@@ -109,27 +116,91 @@ func (onchain *Onchain) Init() {
 	if onchain.LiquidWalletSyncInterval != 0 {
 		onchain.WalletSyncIntervals[boltz.CurrencyLiquid] = time.Duration(onchain.LiquidWalletSyncInterval) * time.Second
 	}
+	if onchain.MaxSyncConcurrency <= 0 {
+		onchain.MaxSyncConcurrency = DefaultMaxSyncConcurrency
+	}
+	onchain.syncSemaphore = make(chan struct{}, onchain.MaxSyncConcurrency)
+}
+
+// acquireSyncSlot blocks until a sync slot is available or the sync context is
+// cancelled. It returns a release function and whether the slot was acquired.
+func (onchain *Onchain) acquireSyncSlot() (func(), bool) {
+	select {
+	case onchain.syncSemaphore <- struct{}{}:
+		return func() { <-onchain.syncSemaphore }, true
+	case <-onchain.syncCtx.Done():
+		return nil, false
+	}
 }
 
 func (onchain *Onchain) AddWallet(wallet Wallet) {
+	onchain.walletsLock.Lock()
 	onchain.Wallets = append(onchain.Wallets, wallet)
+	onchain.walletsLock.Unlock()
 	onchain.OnWalletChange.Send(onchain.Wallets)
 	onchain.startSyncLoop(wallet)
 }
 
 func (onchain *Onchain) RemoveWallet(id Id) {
+	onchain.walletsLock.Lock()
 	onchain.Wallets = slices.DeleteFunc(onchain.Wallets, func(current Wallet) bool {
 		return current.GetWalletInfo().Id == id
 	})
+	onchain.walletsLock.Unlock()
 	onchain.OnWalletChange.Send(onchain.Wallets)
+}
+
+func (onchain *Onchain) hasWallet(wallet Wallet) bool {
+	onchain.walletsLock.RLock()
+	defer onchain.walletsLock.RUnlock()
+	return slices.Contains(onchain.Wallets, wallet)
+}
+
+func (onchain *Onchain) disconnectWallet(wallet Wallet) {
+	if err := wallet.Disconnect(); err != nil {
+		info := wallet.GetWalletInfo()
+		logger.Errorf("Error shutting down wallet %s: %s", info.String(), err.Error())
+	}
+}
+
+// syncWallet returns whether the sync loop should continue. A failed sync is
+// logged but does not stop future attempts.
+func (onchain *Onchain) syncWallet(wallet Wallet, fullScan bool) bool {
+	if !onchain.hasWallet(wallet) {
+		return false
+	}
+	release, ok := onchain.acquireSyncSlot()
+	if !ok {
+		onchain.disconnectWallet(wallet)
+		return false
+	}
+	defer release()
+	if !onchain.hasWallet(wallet) {
+		return false
+	}
+
+	info := wallet.GetWalletInfo()
+	logger.Debugf("Syncing wallet %s", info.String())
+	start := time.Now()
+	var err error
+	if fullScan {
+		err = wallet.FullScan()
+	} else {
+		err = wallet.Sync()
+	}
+	if err != nil {
+		logger.Errorf("Sync for wallet %s failed: %v", info.String(), err)
+	}
+	logger.Debugf("Syncing wallet %s took %s", info.String(), time.Since(start))
+	return true
 }
 
 func (onchain *Onchain) startSyncLoop(wallet Wallet) {
 	onchain.syncWait.Add(1)
 	go func() {
 		defer onchain.syncWait.Done()
-		if err := wallet.FullScan(); err != nil {
-			logger.Errorf("Failed to full scan wallet %s: %v", wallet.GetWalletInfo().String(), err)
+		if !onchain.syncWallet(wallet, true) {
+			return
 		}
 		for {
 			currency := wallet.GetWalletInfo().Currency
@@ -141,22 +212,10 @@ func (onchain *Onchain) startSyncLoop(wallet Wallet) {
 			sleep := time.Duration(float64(interval) * (0.75 + rand.Float64()*0.5))
 			select {
 			case <-onchain.syncCtx.Done():
-				if err := wallet.Disconnect(); err != nil {
-					info := wallet.GetWalletInfo()
-					logger.Errorf("Error shutting down wallet %s: %s", info.String(), err.Error())
-				}
+				onchain.disconnectWallet(wallet)
 				return
 			case <-time.After(sleep):
-				if slices.Contains(onchain.Wallets, wallet) {
-					info := wallet.GetWalletInfo()
-					logger.Debugf("Syncing wallet %s", info.String())
-					start := time.Now()
-					if err := wallet.Sync(); err != nil {
-						logger.Errorf("Sync for wallet %d failed: %v", info.Id, err)
-					}
-					duration := time.Since(start)
-					logger.Debugf("Syncing wallet %s took %s", info.String(), duration)
-				} else {
+				if !onchain.syncWallet(wallet, false) {
 					return
 				}
 			}

--- a/internal/onchain/onchain_test.go
+++ b/internal/onchain/onchain_test.go
@@ -245,8 +245,7 @@ func TestWalletSync(t *testing.T) {
 	})
 
 	t.Run("ConcurrencyLimit", func(t *testing.T) {
-		const maxConcurrency = 2
-		const walletCount = 10
+		const walletCount = 5 * onchain.MaxSyncConcurrency
 
 		onchainInstance := &onchain.Onchain{
 			Btc: &onchain.Currency{
@@ -259,7 +258,6 @@ func TestWalletSync(t *testing.T) {
 				boltz.CurrencyBtc:    syncInterval,
 				boltz.CurrencyLiquid: syncInterval,
 			},
-			MaxSyncConcurrency: maxConcurrency,
 		}
 		onchainInstance.Init()
 		t.Cleanup(onchainInstance.Disconnect)
@@ -291,7 +289,7 @@ func TestWalletSync(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return total.Load() >= walletCount
 		}, 10*time.Second, 10*time.Millisecond, "expected all wallets to sync")
-		require.Equal(t, peak.Load(), int32(maxConcurrency))
+		require.Equal(t, peak.Load(), int32(onchain.MaxSyncConcurrency))
 	})
 
 	t.Run("Disconnect", func(t *testing.T) {

--- a/internal/onchain/onchain_test.go
+++ b/internal/onchain/onchain_test.go
@@ -1,6 +1,8 @@
 package onchain_test
 
 import (
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -218,6 +220,78 @@ func TestWalletSync(t *testing.T) {
 		// we sleep for a few more cycles - if the sync is called again the test will fail
 		// since we only expect it to be called once above
 		time.Sleep(2 * syncInterval)
+	})
+
+	t.Run("FullScanFailure", func(t *testing.T) {
+		onchainInstance := setup(t)
+		t.Cleanup(onchainInstance.Disconnect)
+
+		done := make(chan struct{})
+		wallet := onchainmock.NewMockWallet(t)
+		wallet.EXPECT().FullScan().Return(errors.New("scan failed")).Once()
+		wallet.EXPECT().Sync().RunAndReturn(func() error {
+			close(done)
+			return nil
+		}).Once()
+		wallet.EXPECT().Disconnect().Return(nil).Maybe()
+		wallet.EXPECT().GetWalletInfo().Return(onchain.WalletInfo{Id: 1, Currency: boltz.CurrencyBtc}).Maybe()
+		onchainInstance.AddWallet(wallet)
+
+		select {
+		case <-done:
+		case <-time.After(3 * syncInterval):
+			require.Fail(t, "timed out waiting for sync after full scan failure")
+		}
+	})
+
+	t.Run("ConcurrencyLimit", func(t *testing.T) {
+		const maxConcurrency = 2
+		const walletCount = 10
+
+		onchainInstance := &onchain.Onchain{
+			Btc: &onchain.Currency{
+				Chain: mockBlockProvider(t),
+			},
+			Liquid: &onchain.Currency{
+				Chain: mockBlockProvider(t),
+			},
+			WalletSyncIntervals: map[boltz.Currency]time.Duration{
+				boltz.CurrencyBtc:    syncInterval,
+				boltz.CurrencyLiquid: syncInterval,
+			},
+			MaxSyncConcurrency: maxConcurrency,
+		}
+		onchainInstance.Init()
+		t.Cleanup(onchainInstance.Disconnect)
+
+		var current, peak, total atomic.Int32
+		trackSync := func() error {
+			now := current.Add(1)
+			for {
+				prev := peak.Load()
+				if now <= prev || peak.CompareAndSwap(prev, now) {
+					break
+				}
+			}
+			time.Sleep(syncInterval / 2)
+			current.Add(-1)
+			total.Add(1)
+			return nil
+		}
+
+		for i := range walletCount {
+			wallet := onchainmock.NewMockWallet(t)
+			wallet.EXPECT().FullScan().RunAndReturn(trackSync).Maybe()
+			wallet.EXPECT().Sync().RunAndReturn(trackSync).Maybe()
+			wallet.EXPECT().Disconnect().Return(nil).Maybe()
+			wallet.EXPECT().GetWalletInfo().Return(onchain.WalletInfo{Id: onchain.Id(i + 1), Currency: boltz.CurrencyBtc}).Maybe()
+			onchainInstance.AddWallet(wallet)
+		}
+
+		require.Eventually(t, func() bool {
+			return total.Load() >= walletCount
+		}, 10*time.Second, 10*time.Millisecond, "expected all wallets to sync")
+		require.Equal(t, peak.Load(), int32(maxConcurrency))
 	})
 
 	t.Run("Disconnect", func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to cap concurrent wallet synchronization.
  * Wallet synchronization now runs an initial full scan as part of the normal sync cycle.
* **Bug Fixes**
  * Improved safety when wallets are added or removed during background syncing.
  * Sync work now correctly respects shutdown/cancellation and stops when a wallet is no longer present.
* **Tests**
  * Added coverage to verify the concurrency limit is enforced during wallet syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->