### PR TITLE
fix: backend ci race

### DIFF
--- a/internal/rpcserver/chain_swap_test.go
+++ b/internal/rpcserver/chain_swap_test.go
@@ -107,10 +107,13 @@ func TestChainSwap(t *testing.T) {
 			stream, statusStream := swapStream(t, client, swap.Id)
 
 			test.SendToAddress(test.BtcCli, swap.FromData.LockupAddress, newAmount)
-			test.MineBlock()
-
 			info := statusStream(boltzrpc.SwapState_PENDING, boltz.TransactionLockupFailed)
 			require.Equal(t, newAmount, info.ChainSwap.FromData.Amount)
+
+			// Wait for the backend to finish reprocessing the unconfirmed
+			// transaction with the accepted quote before confirming it.
+			statusStream(boltzrpc.SwapState_PENDING, boltz.TransactionMempool)
+			test.MineBlock()
 
 			update := stream(boltzrpc.SwapState_SUCCESSFUL).ChainSwap
 			require.Equal(t, swap.Id, update.Id)


### PR DESCRIPTION
theres a race where the backend's asnyc handler overwrites the confirmed
with rejected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated chain swap coverage to reflect reduced-amount scenarios.
  * Added validation for intermediate lockup-failure and mempool-pending states before confirming successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->