### PR TITLE
fix(cln): log warning and proceed when chanIds are supplied to PayInvoice

### DIFF
--- a/internal/cln/cln.go
+++ b/internal/cln/cln.go
@@ -224,7 +224,7 @@ func (c *Cln) PayInvoice(ctx context.Context, invoice string, feeLimit uint, tim
 	retry := uint32(timeoutSeconds)
 
 	if len(chanIds) > 0 {
-		return nil, fmt.Errorf("chanIds are not supported for cln")
+		logger.Warnf("chanIds are not supported for cln; ignoring specified chanIds: %v", chanIds)
 	}
 
 	res, err := c.Client.Xpay(ctx, &protos.XpayRequest{

--- a/internal/cln/cln_test.go
+++ b/internal/cln/cln_test.go
@@ -1,0 +1,44 @@
+package cln
+
+import (
+	"context"
+	"testing"
+
+	"github.com/BoltzExchange/boltz-client/v2/internal/cln/protos"
+	"github.com/BoltzExchange/boltz-client/v2/internal/lightning"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type mockNodeClient struct {
+	protos.NodeClient
+	xpayCalled bool
+}
+
+func (m *mockNodeClient) Xpay(ctx context.Context, in *protos.XpayRequest, opts ...grpc.CallOption) (*protos.XpayResponse, error) {
+	m.xpayCalled = true
+	return &protos.XpayResponse{
+		AmountMsat: &protos.Amount{
+			Msat: 100000,
+		},
+		AmountSentMsat: &protos.Amount{
+			Msat: 101000,
+		},
+	}, nil
+}
+
+func TestCln_PayInvoice_ChanIdsWarning(t *testing.T) {
+	mockClient := &mockNodeClient{}
+	clnNode := &Cln{
+		Client: mockClient,
+	}
+
+	// Passing non-empty chanIds should log a warning and proceed with Xpay rather than returning an error
+	chanIds := []lightning.ChanId{12345}
+	res, err := clnNode.PayInvoice(context.Background(), "lnbc...", 1000, 30, chanIds)
+
+	require.NoError(t, err)
+	require.True(t, mockClient.xpayCalled)
+	require.NotNil(t, res)
+	require.Equal(t, uint(1000), res.FeeMsat)
+}


### PR DESCRIPTION
Fixes #718

### Problem
When using Core Lightning (CLN) as the Lightning node backend for `boltz-client`, Lightning autoswap creates reverse swap recommendations containing channel IDs (`reverseSwap.ChanIds`). When `nursery` attempts to pay the invoice for the reverse swap, it passes `chanIds` into `PayInvoice`.

In `internal/cln/cln.go`, `PayInvoice` previously checked:
```go
if len(chanIds) > 0 {
    return nil, fmt.Errorf("chanIds are not supported for cln")
}
```
Because CLN's `Xpay` RPC does not support outgoing channel restriction, returning a hard error caused autoswap-created reverse swaps on CLN nodes to fail immediately.

### Solution
Replace the hard error with a `logger.Warnf` warning log so that `Cln.PayInvoice` logs the unsupported `chanIds` restriction and proceeds to execute `Xpay` to pay the invoice.

### Testing
- Added unit test `TestCln_PayInvoice_ChanIdsWarning` in `internal/cln/cln_test.go` verifying warning fallback and `Xpay` execution.
- Executed `go test -v ./internal/cln/...` in `golang:1.26-bookworm` container:
  ```
  === RUN   TestCln_PayInvoice_ChanIdsWarning
  --- PASS: TestCln_PayInvoice_ChanIdsWarning (0.00s)
  PASS
  ok      github.com/BoltzExchange/boltz-client/v2/internal/cln  0.145s
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Payments now proceed through the CLN payment flow when channel IDs are provided.
  * A warning is logged to indicate that the specified channel IDs are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->